### PR TITLE
Transition node ID mutability fix

### DIFF
--- a/src/contract/assignments.rs
+++ b/src/contract/assignments.rs
@@ -2384,8 +2384,8 @@ mod test {
             .iter()
             .map(|item| {
                 let mut encoder = std::io::Cursor::new(vec![]);
-                item.0.strict_encode(&mut encoder).unwrap();
-                item.1.clone().strict_encode(&mut encoder).unwrap();
+                item.0.commit_encode(&mut encoder);
+                item.1.clone().commit_encode(&mut encoder);
                 MerkleNode::hash(&encoder.into_inner())
             })
             .collect();
@@ -2393,7 +2393,7 @@ mod test {
         let final_node = merklize("", &merkle_nodes[..], 0);
 
         let mut computed_encoding = vec![];
-        final_node.strict_encode(&mut computed_encoding).unwrap();
+        final_node.commit_encode(&mut computed_encoding);
 
         assert_eq!(original_encoding, computed_encoding);
     }

--- a/src/contract/data.rs
+++ b/src/contract/data.rs
@@ -15,6 +15,7 @@ use amplify::AsAny;
 use core::any::Any;
 use core::cmp::Ordering;
 use core::fmt::Debug;
+use std::io;
 
 use bitcoin::hashes::{hash160, sha256, sha256d, sha512, Hash};
 use bitcoin::util::psbt::PartiallySignedTransaction;
@@ -23,6 +24,7 @@ use bitcoin::{secp256k1, Transaction};
 
 use lnpbp::client_side_validation::{
     commit_strategy, CommitEncodeWithStrategy, Conceal,
+    CommitEncode,
 };
 use lnpbp::strict_encoding::strict_serialize;
 
@@ -48,8 +50,8 @@ impl Conceal for Void {
         self.clone()
     }
 }
-impl CommitEncodeWithStrategy for Void {
-    type Strategy = commit_strategy::UsingConceal;
+impl CommitEncode for Void {
+    fn commit_encode<E: io::Write>(self, _e: E) -> usize {0}
 }
 
 #[derive(Clone, Debug, Display, AsAny)]

--- a/src/contract/nodes.rs
+++ b/src/contract/nodes.rs
@@ -271,8 +271,17 @@ impl ConsensusCommit for Transition {
     type Commitment = NodeId;
 }
 
-impl CommitEncodeWithStrategy for Extension {
-    type Strategy = commit_strategy::UsingStrict;
+impl CommitEncode for Extension {
+    fn commit_encode<E: io::Write>(self, mut e: E) -> usize {
+        let mut len = self.extension_type.commit_encode(&mut e);
+        len += self.contract_id.commit_encode(&mut e);
+        len += self.metadata.commit_encode(&mut e);
+        len += self.parent_public_rights.commit_encode(&mut e);
+        len += self.owned_rights.commit_encode(&mut e);
+        len += self.public_rights.commit_encode(&mut e);
+        len += self.script.commit_encode(&mut e);
+        len
+    }
 }
 
 impl CommitEncode for Transition {

--- a/src/contract/nodes.rs
+++ b/src/contract/nodes.rs
@@ -12,6 +12,7 @@
 // If not, see <https://opensource.org/licenses/MIT>.
 
 use std::collections::BTreeSet;
+use std::io;
 
 use amplify::{AsAny, Wrapper};
 use bitcoin::hashes::{sha256, sha256t, Hash};
@@ -274,8 +275,16 @@ impl CommitEncodeWithStrategy for Extension {
     type Strategy = commit_strategy::UsingStrict;
 }
 
-impl CommitEncodeWithStrategy for Transition {
-    type Strategy = commit_strategy::UsingStrict;
+impl CommitEncode for Transition {
+    fn commit_encode<E: io::Write>(self, mut e: E) -> usize {
+        let mut len = self.transition_type.commit_encode(&mut e);
+        len += self.metadata.commit_encode(&mut e);
+        len += self.parent_owned_rights.commit_encode(&mut e);
+        len += self.owned_rights.commit_encode(&mut e);
+        len += self.public_rights.commit_encode(&mut e);
+        len += self.script.commit_encode(&mut e);
+        len
+    }
 }
 
 impl AutoConceal for Genesis {

--- a/src/contract/nodes.rs
+++ b/src/contract/nodes.rs
@@ -773,6 +773,7 @@ mod test {
             script: Default::default(),
         };
 
+        // Strict encode
         let mut encoder = vec![];
         transition
             .transition_type
@@ -791,13 +792,30 @@ mod test {
         transition.script.strict_encode(&mut encoder).unwrap();
 
         let mut encoder1 = vec![];
-        let mut encoder2 = vec![];
+        transition.clone().strict_encode(&mut encoder1).unwrap();
 
-        transition.clone().commit_encode(&mut encoder1);
-        transition.clone().strict_encode(&mut encoder2).unwrap();
-
-        assert_eq!(encoder1, encoder2);
         assert_eq!(encoder, encoder1);
+
+        // Commit encode
+        let transition2 = transition.clone();
+        let mut encoder2 = vec![];
+        transition2
+            .transition_type
+            .commit_encode(&mut encoder2);
+        transition2.metadata.commit_encode(&mut encoder2);
+        transition2
+            .parent_owned_rights
+            .commit_encode(&mut encoder2);
+        transition2.owned_rights.commit_encode(&mut encoder2);
+        transition2
+            .public_rights
+            .commit_encode(&mut encoder2);
+        transition2.script.commit_encode(&mut encoder2);
+
+        let mut encoder3 = vec![];
+        transition.clone().commit_encode(&mut encoder3);
+        
+        assert_eq!(encoder2, encoder3);
     }
 
     #[test]
@@ -818,7 +836,7 @@ mod test {
         );
         assert_eq!(
             transition.node_id().to_hex(),
-            "72a375d75c925aee4e6c077b37cd85eb8a0d3a598d03c3ac038e31a46b145ac6"
+            "e2f910dbebc96dfc804175860758ce5283d61a841c96108550db8c53289298c2"
         );
 
         assert_eq!(genesis.transition_type(), None);
@@ -1034,7 +1052,7 @@ mod test {
         );
         assert_eq!(
             transition.clone().consensus_commit(),
-            NodeId::from_hex("72a375d75c925aee4e6c077b37cd85eb8a0d3a598d03c3ac038e31a46b145ac6")
+            NodeId::from_hex("e2f910dbebc96dfc804175860758ce5283d61a841c96108550db8c53289298c2")
                 .unwrap()
         );
 
@@ -1048,7 +1066,7 @@ mod test {
         );
         assert_eq!(
             transition.clone().consensus_commit(),
-            NodeId::from_hex("0306cc6881cacd66ba1f842fb0b51481789d2580baf0089472ad207989e58670")
+            NodeId::from_hex("e2f910dbebc96dfc804175860758ce5283d61a841c96108550db8c53289298c2")
                 .unwrap()
         );
     }


### PR DESCRIPTION
This is a proposed fix for issue [#133](https://github.com/rgb-org/rgb-node/issues/133) of the `rgb-node` repository.

This essentially replaces the implementation of the CommitEncode trait for the Transition structure. However, for this to be done, several adjustments needed to be made.

That same fix is also applied to the Extension structure, which is very similar to the Transition structure.

NOTE: the implementation of the CommitEncode trait for the Assignments structure (which is part of this pull request) can be simplified if an improvement is made in the `client_side_validation` crate. That improvement has already been proposed via pull request [#178](https://github.com/LNP-BP/rust-lnpbp/pull/178) of the `LNP-BP/rust-lnpbp` repository.