### PR TITLE
Add test function to validate Transition node ID immutability

### DIFF
--- a/src/contract/nodes.rs
+++ b/src/contract/nodes.rs
@@ -825,6 +825,15 @@ mod test {
     }
 
     #[test]
+    fn test_transition_node_id() {
+        let transition = Transition::strict_decode(&TRANSITION[..]).unwrap();
+        let mut concealed_transition = transition.clone();
+        concealed_transition.conceal_all();
+
+        assert_eq!(transition.node_id(), concealed_transition.node_id());
+    }
+
+    #[test]
     fn test_node_attributes() {
         let genesis = Genesis::strict_decode(&GENESIS[..]).unwrap();
         let transition = Transition::strict_decode(&TRANSITION[..]).unwrap();


### PR DESCRIPTION
I propose the addition of a new test function to `contract::nodes` module to help validate the solution for the Transition node ID mutability.