### PR TITLE
Consignment concealment

### DIFF
--- a/src/stash/anchor.rs
+++ b/src/stash/anchor.rs
@@ -331,6 +331,20 @@ impl Anchor {
     pub fn anchor_id(&self) -> AnchorId {
         self.clone().consensus_commit()
     }
+
+    pub fn conceal_except(&mut self, contract_id: ContractId) -> usize {
+        self.commitment.entropy = None;
+        self.commitment.commitments.iter_mut().fold(
+            0usize,
+            |mut count, item| {
+                if item.protocol != Some((*contract_id.as_slice()).into()) {
+                    item.protocol = None;
+                    count += 1;
+                }
+                count
+            },
+        )
+    }
 }
 
 impl CommitEncodeWithStrategy for Anchor {

--- a/src/stash/consignment.rs
+++ b/src/stash/consignment.rs
@@ -18,16 +18,16 @@ use bitcoin::hashes::{sha256, sha256t};
 use bitcoin::Txid;
 use lnpbp::bech32::{self, FromBech32Str, ToBech32String};
 use lnpbp::client_side_validation::{
-    commit_strategy, commit_verify::CommitVerify, CommitEncodeWithStrategy,
-    ConsensusCommit,
+    commit_strategy, commit_verify::CommitVerify, CommitConceal,
+    CommitEncodeWithStrategy, ConsensusCommit,
 };
 use lnpbp::seals::OutpointReveal;
 use lnpbp::TaggedHash;
 use wallet::resolvers::TxResolver;
 
 use crate::{
-    validation, Anchor, Extension, Genesis, Node, NodeId, Schema, SealEndpoint,
-    Transition, Validator,
+    validation, Anchor, ConcealState, ContractId, Extension, Genesis, Node,
+    NodeId, Schema, SealEndpoint, Transition, Validator,
 };
 
 pub type ConsignmentEndpoints = Vec<(NodeId, SealEndpoint)>;
@@ -192,6 +192,40 @@ impl Consignment {
         resolver: R,
     ) -> validation::Status {
         Validator::validate(schema, self, resolver)
+    }
+
+    pub fn finalize(
+        &mut self,
+        expose: &BTreeSet<SealEndpoint>,
+        contract_id: ContractId,
+    ) -> usize {
+        let concealed_endpoints =
+            expose.iter().map(SealEndpoint::commit_conceal).collect();
+
+        let mut count = self.state_transitions.iter_mut().fold(
+            0usize,
+            |count, (anchor, transition)| {
+                count
+                    + anchor.conceal_except(contract_id)
+                    + transition.conceal_state_except(&concealed_endpoints)
+            },
+        );
+
+        count =
+            self.state_extensions
+                .iter_mut()
+                .fold(count, |count, extension| {
+                    count + extension.conceal_state_except(&concealed_endpoints)
+                });
+
+        self.endpoints = self
+            .endpoints
+            .clone()
+            .into_iter()
+            .filter(|(_, endpoint)| expose.contains(endpoint))
+            .collect();
+
+        count
     }
 
     /// Reveals previously known seal information (replacing blind UTXOs with

--- a/src/stash/stash.rs
+++ b/src/stash/stash.rs
@@ -74,7 +74,7 @@ pub trait Stash {
         contract_id: ContractId,
         node: &impl Node,
         anchor: Option<&Anchor>,
-        expose: &BTreeSet<SealEndpoint>,
+        endpoints: &BTreeSet<SealEndpoint>,
     ) -> Result<Consignment, Self::Error>;
 
     /// When we have received data from other peer (which usually relate to our


### PR DESCRIPTION
This provides a special consignment finalization procedure which conceals all non-exportable data. It also specifies that consignment creation API must produce non-concealed version of the consignment (this will require another PR in RGB Node implementation)

UPD: I am temporally merging this commit, since otherwise I can't do required changes in RGB Node because of complex versioning system conflicts, which resolution require updates to a dozen of other crates. Please nevertheless proceed with reviewing this PR, since if there will be amendments, I just revert the merge and merge newer fixed version.