### PR TITLE
contrib/test.sh updated

### DIFF
--- a/contrib/depCargo.toml
+++ b/contrib/depCargo.toml
@@ -1,5 +1,5 @@
 # This is an add-on that must be added to any dependency using this library
 
-rgb = { path = "..", features = ["all"] }
+rgb-core = { path = "..", features = ["all"] }
 
 [workspace]

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -4,16 +4,8 @@ AS_DEPENDENCY=true
 DO_LINT=true
 
 # Library components
-FEATURES="lnp"
-# Cryptographic optionals
-FEATURES="${FEATURES} keygen bulletproofs elgamal"
-# Core rust optionals
-FEATURES="${FEATURES} serde tokio async"
-# Networking
-FEATURES="${FEATURES} tor url websockets"
-FEATURES="${FEATURES} tor,url"
-# Full LNP strength, but without Serde
-FEATURES="${FEATURES} lnp,websockets,url,tokio,async,keygen,bulletproofs"
+FEATURES="cli serde"
+
 
 if [ "$DO_COV" = true ]
 then
@@ -37,11 +29,15 @@ do
     cargo check --verbose --features="$feature" --all-targets
 done
 
-# Check that we can build services with different features
-for feature in "server client embedded cli server,serde client,serde"
+# Check that we can build rgb* crates
+for crate in rgb20 rgb21 rgb22 rgb23
 do
-    cargo check --manifest-path services/Cargo.toml --verbose --features="$feature"
+    cargo check --manifest-path $crate/Cargo.toml --verbose --features all
 done
+
+# Check that we can build rgb binary
+# rgb binary is not building by following command and I am not sure why
+cargo check --bins --features all --verbose
 
 # Fuzz if told to
 if [ "$DO_FUZZ" = true ]


### PR DESCRIPTION
Updates the `./contrib/test.sh` file.

Fixes #24 

Issues: 

- `Consignment` encoding decoding test is failing because node structure has been refactored and `./test/consignment.in` data is not consistent with the current structure. I couldn't find an easier way to create the latest consignment data to update it, and rgb-node doesn't include the latest changes yet. Can be fixed easily when we are done with core level refactoring.

- `rgb` binary used for conversion tooling is not being built, and I am not exactly sure why.

  