### PR TITLE
Fix anchor commitment check

### DIFF
--- a/src/validation.rs
+++ b/src/validation.rs
@@ -588,7 +588,7 @@ impl<'consignment, 'resolver, C: Consignment<'consignment>, R: ResolveTx>
                 //               commitment
                 if anchor
                     .verify(self.contract_id, bundle_id.into(), witness_tx.clone())
-                    .is_ok()
+                    .is_err()
                 {
                     // TODO: Save error details
                     // The node is not committed to bitcoin transaction graph!


### PR DESCRIPTION
Seems to be an oversight, I think we should add a failure only if `anchor.verify()` returns an error