### PR TITLE
Update dependencies and bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,9 +336,9 @@ dependencies = [
 
 [[package]]
 name = "commit_verify"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e435fa675ad24cb6cf205ec9269e5ca7b650a27c39c0d0b7a20e05218a4cfa"
+checksum = "3becf28181780bcd77a2a0f844aa11d07aa24ad2df68b43d7715c0218b2f0465"
 dependencies = [
  "amplify",
  "bitcoin_hashes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgb-core"
-version = "0.8.1"
+version = "0.8.2"
 license = "MIT"
 authors = ["Dr Maxim Orlovsky <orlovsky@lnp-bp.org>"]
 description = "RGB Core Library: consensus & verification for private & scalable client-validated smart contracts on Bitcoin & Lightning"
@@ -39,9 +39,9 @@ amplify = { version = "~3.13.0", features = ["apfloat"] }
 bp-core = { version = "~0.8.1" }
 lnpbp = { version = "~0.8.0", features = ["zip"] }
 stens = "~0.7.1"
-strict_encoding = { version = "~0.8.0", features = ["crypto", "chrono", "bitcoin", "float"] }
-commit_verify = { version = "~0.8.1", features = ["rand", "bulletproofs"] }
-descriptor-wallet = "~0.8.0"
+strict_encoding = { version = "~0.8.2", features = ["crypto", "chrono", "bitcoin", "float"] }
+commit_verify = { version = "~0.8.2", features = ["rand", "bulletproofs"] }
+descriptor-wallet = "~0.8.3"
 aluvm = { version = "~0.7.0", features = ["std", "strict_encoding"] }
 # Dependencies on core rust-bitcoin ecosystem projects
 # ----------------------------------------------------


### PR DESCRIPTION
This updates RGB Core library to a fixed version of LNPBP4 Merkle block merge algorithm from https://github.com/LNP-BP/client_side_validation/pull/116