### PR TITLE
Fix SchemaGlobalStateLimit Validation

### DIFF
--- a/src/validation/model.rs
+++ b/src/validation/model.rs
@@ -243,7 +243,7 @@ impl<Root: SchemaRoot> Schema<Root> {
                     opid, *type_id, err,
                 ));
             }
-            if count >= *max_items {
+            if count > *max_items {
                 status.add_failure(validation::Failure::SchemaGlobalStateLimit(
                     opid, *type_id, count, *max_items,
                 ));


### PR DESCRIPTION
Hi @dr-orlovsky,

I tried to validate a Schema containing only a **Nominal** field and a **ContractText** field, but does not working!

This PR fixes Global State Limit validation when the number of occurrences equals 1.