### PR TITLE
Fix operation id by using proper conceal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,12 +303,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "commit_verify"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a517ba2f2008e980c6cefe0553a7b56541b0a129e9e809d36770c9b1c6429c1b"
+name = "commit_encoding_derive"
+version = "0.10.0-beta.1"
+source = "git+https://github.com/LNP-BP/client_side_validation?branch=commit_encode_derive#9d997deb21b5a4b9b5439edfe895766fd2077c3d"
 dependencies = [
  "amplify",
+ "amplify_syn",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "commit_verify"
+version = "0.10.1"
+source = "git+https://github.com/LNP-BP/client_side_validation?branch=commit_encode_derive#9d997deb21b5a4b9b5439edfe895766fd2077c3d"
+dependencies = [
+ "amplify",
+ "commit_encoding_derive",
  "rand",
  "serde",
  "strict_encoding",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,8 +197,7 @@ dependencies = [
 [[package]]
 name = "bp-core"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f410514e60dacfb6deba8629db1d267878174281bee45e459b09adaed38e4769"
+source = "git+https://github.com/BP-WG/bp-core?branch=commit_derive#fb7405417fd2aef5a953097cf056e90b2af5e296"
 dependencies = [
  "amplify",
  "bp-dbc",
@@ -213,8 +212,7 @@ dependencies = [
 [[package]]
 name = "bp-dbc"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74e0814e4d2c560767853bba914749bb571ea074caddade66fe15db16b4a1e17"
+source = "git+https://github.com/BP-WG/bp-core?branch=commit_derive#fb7405417fd2aef5a953097cf056e90b2af5e296"
 dependencies = [
  "amplify",
  "baid58",
@@ -228,8 +226,7 @@ dependencies = [
 [[package]]
 name = "bp-primitives"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0daf04647d5ea2465de0a1ab27b8bb6abb01bd7c84e99c65a5ca50440cca30be"
+source = "git+https://github.com/BP-WG/bp-core?branch=commit_derive#fb7405417fd2aef5a953097cf056e90b2af5e296"
 dependencies = [
  "amplify",
  "commit_verify",
@@ -241,8 +238,7 @@ dependencies = [
 [[package]]
 name = "bp-seals"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e99c62130e9b9e8422f69c84a492494b637247b0c13ba463b78fdfd34bbe887"
+source = "git+https://github.com/BP-WG/bp-core?branch=commit_derive#fb7405417fd2aef5a953097cf056e90b2af5e296"
 dependencies = [
  "amplify",
  "baid58",
@@ -305,7 +301,7 @@ dependencies = [
 [[package]]
 name = "commit_encoding_derive"
 version = "0.10.0-beta.1"
-source = "git+https://github.com/LNP-BP/client_side_validation?branch=commit_encode_derive#9d997deb21b5a4b9b5439edfe895766fd2077c3d"
+source = "git+https://github.com/LNP-BP/client_side_validation?branch=commit_encode_derive#bb1567daff74fbc243638256434a322562989fd1"
 dependencies = [
  "amplify",
  "amplify_syn",
@@ -317,7 +313,7 @@ dependencies = [
 [[package]]
 name = "commit_verify"
 version = "0.10.1"
-source = "git+https://github.com/LNP-BP/client_side_validation?branch=commit_encode_derive#9d997deb21b5a4b9b5439edfe895766fd2077c3d"
+source = "git+https://github.com/LNP-BP/client_side_validation?branch=commit_encode_derive#bb1567daff74fbc243638256434a322562989fd1"
 dependencies = [
  "amplify",
  "commit_encoding_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,3 +57,7 @@ features = [ "all" ]
 
 [patch.crates-io]
 commit_verify = { git = "https://github.com/LNP-BP/client_side_validation", branch = "commit_encode_derive" }
+bp-core = { git = "https://github.com/BP-WG/bp-core", branch = "commit_derive" }
+bp-primitives = { git = "https://github.com/BP-WG/bp-core", branch = "commit_derive" }
+bp-dbc = { git = "https://github.com/BP-WG/bp-core", branch = "commit_derive" }
+bp-seals = { git = "https://github.com/BP-WG/bp-core", branch = "commit_derive" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ amplify = "~4.0.0"
 strict_encoding = "~2.1.1"
 strict_types = "~1.1.0"
 aluvm = { version = "~0.10.1", features = ["std"] }
-commit_verify = { version = "~0.10.0", features = ["rand"] }
+commit_verify = { version = "~0.10.1", features = ["rand", "derive"] }
 single_use_seals = "~0.10.0"
 bp-core = { version = "~0.10.1" }
 secp256k1-zkp = { version = "~0.7.0", features = ["use-rand", "rand-std", "global-context"] }
@@ -54,3 +54,6 @@ wasm-bindgen-test = "0.3"
 
 [package.metadata.docs.rs]
 features = [ "all" ]
+
+[patch.crates-io]
+commit_verify = { git = "https://github.com/LNP-BP/client_side_validation", branch = "commit_encode_derive" }

--- a/src/contract/assignments.rs
+++ b/src/contract/assignments.rs
@@ -541,9 +541,9 @@ impl<Seal: ExposedSeal> CommitStrategy for TypedAssigns<Seal> {
 
 impl<Seal: ExposedSeal> MerkleLeaves for TypedAssigns<Seal> {
     type Leaf = MerkleNode;
-    type LeafIter = vec::IntoIter<MerkleNode>;
+    type LeafIter<'tmp> = vec::IntoIter<MerkleNode> where Self: 'tmp;
 
-    fn merkle_leaves(&self) -> Self::LeafIter {
+    fn merkle_leaves(&self) -> Self::LeafIter<'_> {
         match self {
             TypedAssigns::Declarative(vec) => vec
                 .iter()

--- a/src/contract/assignments.rs
+++ b/src/contract/assignments.rs
@@ -226,16 +226,30 @@ where Self: Clone
     }
 }
 
-// We can't use `UsingConceal` strategy here since it relies on the
-// `commit_encode` of the concealed type, and here the concealed type is again
-// `OwnedState`, leading to a recurrency. So we use `strict_encode` of the
-// concealed data.
+// We do not derive here since we omit serialization of the tag: all data are
+// concealed, thus no tag is needed.
 impl<State: ExposedState, Seal: ExposedSeal> CommitEncode for Assign<State, Seal>
 where Self: Clone
 {
     fn commit_encode(&self, e: &mut impl io::Write) {
-        let w = StrictWriter::with(u32::MAX as usize, e);
-        self.conceal().strict_encode(w).ok();
+        match self {
+            Assign::Confidential { seal, state } => {
+                seal.commit_encode(e);
+                state.commit_encode(e);
+            }
+            Assign::ConfidentialState { seal, state } => {
+                seal.commit_encode(e);
+                state.commit_encode(e);
+            }
+            Assign::Revealed { seal, state } => {
+                seal.commit_encode(e);
+                state.commit_encode(e);
+            }
+            Assign::ConfidentialSeal { seal, state } => {
+                seal.commit_encode(e);
+                state.commit_encode(e);
+            }
+        }
     }
 }
 

--- a/src/contract/assignments.rs
+++ b/src/contract/assignments.rs
@@ -293,6 +293,34 @@ pub enum TypedAssigns<Seal: ExposedSeal> {
     Attachment(SmallVec<AssignAttach<Seal>>),
 }
 
+impl<Seal: ExposedSeal> Conceal for TypedAssigns<Seal> {
+    type Concealed = Self;
+    fn conceal(&self) -> Self::Concealed {
+        match self {
+            TypedAssigns::Declarative(s) => {
+                let concealed_iter = s.iter().map(AssignRights::<Seal>::conceal);
+                let inner = SmallVec::try_from_iter(concealed_iter).expect("same size");
+                TypedAssigns::Declarative(inner)
+            }
+            TypedAssigns::Fungible(s) => {
+                let concealed_iter = s.iter().map(AssignFungible::<Seal>::conceal);
+                let inner = SmallVec::try_from_iter(concealed_iter).expect("same size");
+                TypedAssigns::Fungible(inner)
+            }
+            TypedAssigns::Structured(s) => {
+                let concealed_iter = s.iter().map(AssignData::<Seal>::conceal);
+                let inner = SmallVec::try_from_iter(concealed_iter).expect("same size");
+                TypedAssigns::Structured(inner)
+            }
+            TypedAssigns::Attachment(s) => {
+                let concealed_iter = s.iter().map(AssignAttach::<Seal>::conceal);
+                let inner = SmallVec::try_from_iter(concealed_iter).expect("same size");
+                TypedAssigns::Attachment(inner)
+            }
+        }
+    }
+}
+
 impl<Seal: ExposedSeal> TypedAssigns<Seal> {
     pub fn is_empty(&self) -> bool {
         match self {

--- a/src/contract/attachment.rs
+++ b/src/contract/attachment.rs
@@ -25,7 +25,7 @@ use std::str::FromStr;
 use amplify::{Bytes32, RawArray};
 use baid58::{Baid58ParseError, FromBaid58, ToBaid58};
 use bp::secp256k1::rand::{thread_rng, RngCore};
-use commit_verify::{CommitStrategy, CommitVerify, Conceal, StrictEncodedProtocol};
+use commit_verify::{CommitVerify, Conceal, StrictEncodedProtocol};
 use strict_encoding::StrictEncode;
 
 use super::{ConfidentialState, ExposedState};
@@ -62,6 +62,8 @@ impl FromStr for AttachId {
 #[derive(Clone, PartialOrd, Ord, PartialEq, Eq, Hash, Debug)]
 #[derive(StrictType, StrictDumb, StrictEncode, StrictDecode)]
 #[strict_type(lib = LIB_NAME_RGB)]
+#[derive(CommitEncode)]
+#[commit_encode(conceal, strategy = strict)]
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),
@@ -98,9 +100,6 @@ impl Conceal for RevealedAttach {
 
     fn conceal(&self) -> Self::Concealed { ConcealedAttach::commit(self) }
 }
-impl CommitStrategy for RevealedAttach {
-    type Strategy = commit_verify::strategies::ConcealStrict;
-}
 
 /// Confidential version of an attachment information.
 ///
@@ -109,6 +108,8 @@ impl CommitStrategy for RevealedAttach {
 #[wrapper(Deref, BorrowSlice, Hex, Index, RangeOps)]
 #[derive(StrictType, StrictDumb, StrictEncode, StrictDecode)]
 #[strict_type(lib = LIB_NAME_RGB)]
+#[derive(CommitEncode)]
+#[commit_encode(strategy = strict)]
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),
@@ -123,10 +124,6 @@ pub struct ConcealedAttach(
 impl ConfidentialState for ConcealedAttach {
     fn state_type(&self) -> StateType { StateType::Attachment }
     fn state_commitment(&self) -> StateCommitment { StateCommitment::Attachment(*self) }
-}
-
-impl CommitStrategy for ConcealedAttach {
-    type Strategy = commit_verify::strategies::Strict;
 }
 
 impl CommitVerify<RevealedAttach, StrictEncodedProtocol> for ConcealedAttach {

--- a/src/contract/contract.rs
+++ b/src/contract/contract.rs
@@ -385,7 +385,7 @@ impl ContractHistory {
         }
 
         // Remove invalidated state
-        for input in op.inputs() {
+        for input in &op.inputs() {
             if let Some(o) = self.rights.iter().find(|r| r.opout == input.prev_out) {
                 let o = o.clone(); // need this b/c of borrow checker
                 self.rights

--- a/src/contract/fungible.rs
+++ b/src/contract/fungible.rs
@@ -427,12 +427,16 @@ mod test {
     use super::*;
 
     #[test]
-    fn concealed_commitments_determinism() {
+    fn commitments_determinism() {
         let value = RevealedValue::new(15, &mut thread_rng());
 
         let generators = (0..10)
             .into_iter()
-            .map(|_| ConcealedValue::commit(&value).commitment)
+            .map(|_| {
+                let mut val = vec![];
+                value.commit_encode(&mut val);
+                val
+            })
             .collect::<HashSet<_>>();
         assert_eq!(generators.len(), 1);
     }

--- a/src/contract/fungible.rs
+++ b/src/contract/fungible.rs
@@ -374,14 +374,14 @@ impl CommitVerify<RevealedValue, PedersenProtocol> for ConcealedValue {
         let commitment = PedersenCommitment::commit(revealed);
         // TODO: Do actual conceal upon integration of bulletproofs library
         let range_proof = RangeProof::default();
-        let _ = ConcealedValue {
+        eprintln!(
+            "Warning: current version of RGB Core doesn't support production of bulletproofs; \
+             make sure concealed data are not saved since their state will be lost"
+        );
+        ConcealedValue {
             commitment,
             range_proof,
-        };
-        panic!(
-            "current version of RGB Core doesn't support production of bulletproofs. The method \
-             leading to this panic must not be used for now."
-        );
+        }
     }
 }
 

--- a/src/contract/fungible.rs
+++ b/src/contract/fungible.rs
@@ -420,3 +420,21 @@ impl ConcealedValue {
         Err(RangeProofError::BulletproofsAbsent)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use std::collections::HashSet;
+
+    use super::*;
+
+    #[test]
+    fn concealed_commitments_determinism() {
+        let value = RevealedValue::new(15, &mut thread_rng());
+
+        let generators = (0..10)
+            .into_iter()
+            .map(|_| ConcealedValue::commit(&value).commitment)
+            .collect::<HashSet<_>>();
+        assert_eq!(generators.len(), 1);
+    }
+}

--- a/src/contract/fungible.rs
+++ b/src/contract/fungible.rs
@@ -375,7 +375,7 @@ impl ConfidentialState for ConcealedValue {
 }
 
 impl CommitVerify<RevealedValue, PedersenProtocol> for ConcealedValue {
-    #[allow(dead_code, unreachable_code)]
+    #[allow(dead_code, unreachable_code, unused_variables)]
     fn commit(revealed: &RevealedValue) -> Self {
         panic!(
             "Error: current version of RGB Core doesn't support production of bulletproofs; thus, \

--- a/src/contract/global.rs
+++ b/src/contract/global.rs
@@ -61,6 +61,8 @@ impl IntoIterator for GlobalValues {
 #[wrapper_mut(DerefMut)]
 #[derive(StrictType, StrictEncode, StrictDecode)]
 #[strict_type(lib = LIB_NAME_RGB)]
+#[derive(CommitEncode)]
+#[commit_encode(strategy = strict)]
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),

--- a/src/contract/operations.rs
+++ b/src/contract/operations.rs
@@ -21,6 +21,8 @@
 // limitations under the License.
 
 use std::cmp::Ordering;
+use std::collections::{btree_map, btree_set};
+use std::iter;
 use std::str::FromStr;
 
 use amplify::confinement::{SmallBlob, TinyOrdMap, TinyOrdSet};
@@ -37,9 +39,68 @@ use crate::{
     ReservedByte, TypedAssigns, LIB_NAME_RGB,
 };
 
-pub type Valencies = TinyOrdSet<schema::ValencyType>;
-pub type Inputs = TinyOrdSet<Input>;
-pub type Redeemed = TinyOrdMap<schema::ValencyType, OpId>;
+#[derive(Wrapper, WrapperMut, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug, Default, From)]
+#[wrapper(Deref)]
+#[wrapper_mut(DerefMut)]
+#[derive(StrictType, StrictEncode, StrictDecode)]
+#[strict_type(lib = LIB_NAME_RGB)]
+#[derive(CommitEncode)]
+#[commit_encode(strategy = strict)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate", rename_all = "camelCase")
+)]
+pub struct Valencies(TinyOrdSet<schema::ValencyType>);
+
+impl<'a> IntoIterator for &'a Valencies {
+    type Item = schema::ValencyType;
+    type IntoIter = iter::Copied<btree_set::Iter<'a, schema::ValencyType>>;
+
+    fn into_iter(self) -> Self::IntoIter { self.0.iter().copied() }
+}
+
+#[derive(Wrapper, WrapperMut, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug, Default, From)]
+#[wrapper(Deref)]
+#[wrapper_mut(DerefMut)]
+#[derive(StrictType, StrictEncode, StrictDecode)]
+#[strict_type(lib = LIB_NAME_RGB)]
+#[derive(CommitEncode)]
+#[commit_encode(strategy = strict)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate", rename_all = "camelCase")
+)]
+pub struct Redeemed(TinyOrdMap<schema::ValencyType, OpId>);
+
+impl<'a> IntoIterator for &'a Redeemed {
+    type Item = (&'a schema::ValencyType, &'a OpId);
+    type IntoIter = btree_map::Iter<'a, schema::ValencyType, OpId>;
+
+    fn into_iter(self) -> Self::IntoIter { self.0.iter() }
+}
+
+#[derive(Wrapper, WrapperMut, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug, Default, From)]
+#[wrapper(Deref)]
+#[wrapper_mut(DerefMut)]
+#[derive(StrictType, StrictEncode, StrictDecode)]
+#[strict_type(lib = LIB_NAME_RGB)]
+#[derive(CommitEncode)]
+#[commit_encode(strategy = strict)]
+#[cfg_attr(
+    feature = "serde",
+    derive(Serialize, Deserialize),
+    serde(crate = "serde_crate", rename_all = "camelCase")
+)]
+pub struct Inputs(TinyOrdSet<Input>);
+
+impl<'a> IntoIterator for &'a Inputs {
+    type Item = Input;
+    type IntoIter = iter::Copied<btree_set::Iter<'a, Input>>;
+
+    fn into_iter(self) -> Self::IntoIter { self.0.iter().copied() }
+}
 
 #[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug, Display)]
 #[derive(StrictType, StrictDumb, StrictEncode, StrictDecode)]

--- a/src/contract/operations.rs
+++ b/src/contract/operations.rs
@@ -28,7 +28,7 @@ use amplify::hex::{FromHex, ToHex};
 use amplify::{hex, Bytes32, RawArray, Wrapper};
 use baid58::{Baid58ParseError, FromBaid58, ToBaid58};
 use bp::Chain;
-use commit_verify::{mpc, CommitStrategy, CommitmentId, Conceal};
+use commit_verify::{mpc, CommitmentId, Conceal};
 use strict_encoding::{StrictDeserialize, StrictEncode, StrictSerialize};
 
 use crate::schema::{self, ExtensionType, OpFullType, OpType, SchemaId, TransitionType};
@@ -198,6 +198,7 @@ pub trait Operation {
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 #[derive(StrictType, StrictDumb, StrictEncode, StrictDecode)]
 #[strict_type(lib = LIB_NAME_RGB)]
+#[derive(CommitEncode)]
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),
@@ -219,6 +220,7 @@ impl StrictDeserialize for Genesis {}
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 #[derive(StrictType, StrictDumb, StrictEncode, StrictDecode)]
 #[strict_type(lib = LIB_NAME_RGB)]
+#[derive(CommitEncode)]
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),
@@ -241,6 +243,7 @@ impl StrictDeserialize for Extension {}
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 #[derive(StrictType, StrictDumb, StrictEncode, StrictDecode)]
 #[strict_type(lib = LIB_NAME_RGB)]
+#[derive(CommitEncode)]
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),
@@ -269,10 +272,6 @@ impl PartialOrd for Transition {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> { Some(self.cmp(other)) }
 }
 
-impl CommitStrategy for Genesis {
-    type Strategy = commit_verify::strategies::ConcealStrict;
-}
-
 impl Conceal for Genesis {
     type Concealed = Genesis;
     fn conceal(&self) -> Self::Concealed {
@@ -290,10 +289,6 @@ impl CommitmentId for Genesis {
     type Id = ContractId;
 }
 
-impl CommitStrategy for Transition {
-    type Strategy = commit_verify::strategies::ConcealStrict;
-}
-
 impl Conceal for Transition {
     type Concealed = Transition;
     fn conceal(&self) -> Self::Concealed {
@@ -309,10 +304,6 @@ impl Conceal for Transition {
 impl CommitmentId for Transition {
     const TAG: [u8; 32] = *b"urn:lnpbp:rgb:transition:v02#23B";
     type Id = OpId;
-}
-
-impl CommitStrategy for Extension {
-    type Strategy = commit_verify::strategies::ConcealStrict;
 }
 
 impl Conceal for Extension {

--- a/src/contract/operations.rs
+++ b/src/contract/operations.rs
@@ -28,7 +28,7 @@ use amplify::hex::{FromHex, ToHex};
 use amplify::{hex, Bytes32, RawArray, Wrapper};
 use baid58::{Baid58ParseError, FromBaid58, ToBaid58};
 use bp::Chain;
-use commit_verify::{mpc, CommitStrategy, CommitmentId};
+use commit_verify::{mpc, CommitStrategy, CommitmentId, Conceal};
 use strict_encoding::{StrictDeserialize, StrictEncode, StrictSerialize};
 
 use crate::schema::{self, ExtensionType, OpFullType, OpType, SchemaId, TransitionType};
@@ -270,29 +270,65 @@ impl PartialOrd for Transition {
 }
 
 impl CommitStrategy for Genesis {
-    type Strategy = commit_verify::strategies::Strict;
+    type Strategy = commit_verify::strategies::ConcealStrict;
+}
+
+impl Conceal for Genesis {
+    type Concealed = Genesis;
+    fn conceal(&self) -> Self::Concealed {
+        let mut concealed = self.clone();
+        concealed
+            .assignments
+            .keyed_values_mut()
+            .for_each(|(_, a)| *a = a.conceal());
+        concealed
+    }
 }
 
 impl CommitmentId for Genesis {
-    const TAG: [u8; 32] = *b"urn:lnpbp:rgb:genesis:v01#202302";
+    const TAG: [u8; 32] = *b"urn:lnpbp:rgb:genesis:v02#202304";
     type Id = ContractId;
 }
 
 impl CommitStrategy for Transition {
-    type Strategy = commit_verify::strategies::Strict;
+    type Strategy = commit_verify::strategies::ConcealStrict;
+}
+
+impl Conceal for Transition {
+    type Concealed = Transition;
+    fn conceal(&self) -> Self::Concealed {
+        let mut concealed = self.clone();
+        concealed
+            .assignments
+            .keyed_values_mut()
+            .for_each(|(_, a)| *a = a.conceal());
+        concealed
+    }
 }
 
 impl CommitmentId for Transition {
-    const TAG: [u8; 32] = *b"urn:lnpbp:rgb:transition:v01#32A";
+    const TAG: [u8; 32] = *b"urn:lnpbp:rgb:transition:v02#23B";
     type Id = OpId;
 }
 
 impl CommitStrategy for Extension {
-    type Strategy = commit_verify::strategies::Strict;
+    type Strategy = commit_verify::strategies::ConcealStrict;
+}
+
+impl Conceal for Extension {
+    type Concealed = Extension;
+    fn conceal(&self) -> Self::Concealed {
+        let mut concealed = self.clone();
+        concealed
+            .assignments
+            .keyed_values_mut()
+            .for_each(|(_, a)| *a = a.conceal());
+        concealed
+    }
 }
 
 impl CommitmentId for Extension {
-    const TAG: [u8; 32] = *b"urn:lnpbp:rgb:extension:v01#2023";
+    const TAG: [u8; 32] = *b"urn:lnpbp:rgb:extension:v02#2304";
     type Id = OpId;
 }
 

--- a/src/contract/seal.rs
+++ b/src/contract/seal.rs
@@ -28,7 +28,7 @@ pub use bp::seals::txout::blind::{
 };
 pub use bp::seals::txout::TxoSeal;
 use bp::Txid;
-use commit_verify::Conceal;
+use commit_verify::{CommitEncode, Conceal};
 use strict_encoding::{StrictDecode, StrictDumb, StrictEncode};
 
 use crate::LIB_NAME_RGB;
@@ -38,6 +38,7 @@ pub trait ExposedSeal:
     + StrictDumb
     + StrictEncode
     + StrictDecode
+    + CommitEncode
     + Conceal<Concealed = SecretSeal>
     + Eq
     + Ord

--- a/src/contract/state.rs
+++ b/src/contract/state.rs
@@ -23,7 +23,7 @@
 use core::fmt::Debug;
 use core::hash::Hash;
 
-use commit_verify::Conceal;
+use commit_verify::{CommitEncode, Conceal};
 use strict_encoding::{StrictDecode, StrictDumb, StrictEncode};
 
 use crate::{
@@ -34,7 +34,7 @@ use crate::{
 /// Marker trait for types of state which are just a commitment to the actual
 /// state data.
 pub trait ConfidentialState:
-    Debug + Hash + StrictDumb + StrictEncode + StrictDecode + Eq + Copy
+    Debug + Hash + StrictDumb + StrictEncode + StrictDecode + CommitEncode + Eq + Copy
 {
     fn state_type(&self) -> StateType;
     fn state_commitment(&self) -> StateCommitment;
@@ -47,6 +47,7 @@ pub trait ExposedState:
     + StrictEncode
     + StrictDecode
     + Conceal<Concealed = Self::Confidential>
+    + CommitEncode
     + Eq
     + Ord
     + Clone
@@ -83,6 +84,7 @@ pub enum StateType {
 #[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug)]
 #[derive(StrictType, StrictDumb, StrictEncode, StrictDecode)]
 #[strict_type(lib = LIB_NAME_RGB, tags = custom)]
+#[derive(CommitEncode)]
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),
@@ -127,6 +129,7 @@ impl Conceal for StateData {
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 #[derive(StrictType, StrictDumb, StrictEncode, StrictDecode)]
 #[strict_type(lib = LIB_NAME_RGB, tags = custom)]
+#[derive(CommitEncode)]
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,8 @@
 extern crate amplify;
 #[macro_use]
 extern crate strict_encoding;
+#[macro_use]
+extern crate commit_verify;
 
 #[cfg(feature = "serde")]
 #[macro_use]
@@ -99,6 +101,8 @@ mod _reserved {
 #[display("v0.10.0+{0}")]
 #[derive(StrictType, StrictEncode)]
 #[strict_type(lib = LIB_NAME_RGB)]
+#[derive(CommitEncode)]
+#[commit_encode(strategy = strict)]
 #[cfg_attr(
     feature = "serde",
     derive(Serialize, Deserialize),


### PR DESCRIPTION
This should be a solution for the https://github.com/RGB-WG/rgb-wallet/issues/36 issue. Please test it in your projects by adding

```toml
[patch.crates-io]
rgb-core = { git = "https://github.com/RGB-WG/rgb-core", branch = "fix/op-conceal" }
```

to your workspace-level `Cargo.toml` files

(of course you need to start with new stash and issuing new contracts, otherwise it won't work)