### PR TITLE
Release v0.10.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,8 +193,9 @@ dependencies = [
 
 [[package]]
 name = "bp-consensus"
-version = "0.10.10"
-source = "git+https://github.com/BP-WG/bp-core?branch=consensus#48d79c9f210772dbd836aba258fa836169e8c36d"
+version = "0.10.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d7b87840e5fc65bcbcd3881e0a0150ecef4a9b18b1356eb7a8a9adc85280c63"
 dependencies = [
  "amplify",
  "chrono",
@@ -207,8 +208,9 @@ dependencies = [
 
 [[package]]
 name = "bp-core"
-version = "0.10.10"
-source = "git+https://github.com/BP-WG/bp-core?branch=consensus#48d79c9f210772dbd836aba258fa836169e8c36d"
+version = "0.10.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8b5219d96064b5d277c166fd5321ce6ee3e8a74e50bf2281d47726f365ead4"
 dependencies = [
  "amplify",
  "bp-consensus",
@@ -223,8 +225,9 @@ dependencies = [
 
 [[package]]
 name = "bp-dbc"
-version = "0.10.10"
-source = "git+https://github.com/BP-WG/bp-core?branch=consensus#48d79c9f210772dbd836aba258fa836169e8c36d"
+version = "0.10.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e265b111f61acb39cf36778c4da9a3d3c49fcc7a7e4116fd40ab250d598b1280"
 dependencies = [
  "amplify",
  "base85",
@@ -237,8 +240,9 @@ dependencies = [
 
 [[package]]
 name = "bp-seals"
-version = "0.10.10"
-source = "git+https://github.com/BP-WG/bp-core?branch=consensus#48d79c9f210772dbd836aba258fa836169e8c36d"
+version = "0.10.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ccb60735209233ece5927a5c66355037af8479104b5ff55371ae4a0f53c96b2"
 dependencies = [
  "amplify",
  "baid58",
@@ -1093,3 +1097,23 @@ checksum = "037711d82167854aff2018dfd193aa0fef5370f456732f0d5a0c59b0f1b4b907"
 dependencies = [
  "memchr",
 ]
+
+[[patch.unused]]
+name = "bp-consensus"
+version = "0.10.10"
+source = "git+https://github.com/BP-WG/bp-core?branch=consensus#48d79c9f210772dbd836aba258fa836169e8c36d"
+
+[[patch.unused]]
+name = "bp-core"
+version = "0.10.10"
+source = "git+https://github.com/BP-WG/bp-core?branch=consensus#48d79c9f210772dbd836aba258fa836169e8c36d"
+
+[[patch.unused]]
+name = "bp-dbc"
+version = "0.10.10"
+source = "git+https://github.com/BP-WG/bp-core?branch=consensus#48d79c9f210772dbd836aba258fa836169e8c36d"
+
+[[patch.unused]]
+name = "bp-seals"
+version = "0.10.10"
+source = "git+https://github.com/BP-WG/bp-core?branch=consensus#48d79c9f210772dbd836aba258fa836169e8c36d"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,7 +593,7 @@ dependencies = [
 
 [[package]]
 name = "rgb-core"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [
  "aluvm",
  "amplify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ strict_types = "~1.6.3"
 aluvm = { version = "~0.10.6", features = ["std"] }
 commit_verify = { version = "~0.10.6", features = ["rand", "derive"] }
 single_use_seals = "~0.10.1"
-bp-core = { version = "~0.10.10" }
+bp-core = { version = "~0.10.11" }
 secp256k1-zkp = { version = "0.9.2", features = ["rand", "rand-std", "global-context"] }
 baid58 = "~0.4.4"
 mime = "~0.3.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgb-core"
-version = "0.10.7"
+version = "0.10.8"
 authors = ["Dr Maxim Orlovsky <orlovsky@lnp-bp.org>"]
 description = "RGB Core Library: confidential & scalable smart contracts on Bitcoin & Lightning (consensus layer)"
 repository = "https://github.com/RGB-WG/rgb-core"


### PR DESCRIPTION
Will wait until both @zoedberg and @cryptoquick will confirm that their systems works against this release.

There were no significant changes - just API refinement, rust lints and dependency updates - but there was a lot of new code in BP consensus which was added (and not used in RGB). Nothing in strict types shows that any RGB-related data had changed - and downstream everything compiles against this release - but just in case, want to make sure that for you guys everything also works as expected.