### PR TITLE
API sanation for state types

### DIFF
--- a/src/contract/contract.rs
+++ b/src/contract/contract.rs
@@ -95,7 +95,7 @@ impl FromStr for Opout {
 /// Trait used by contract state. Unlike [`ExposedState`] it doesn't allow
 /// concealment of the state, i.e. may contain incomplete data without blinding
 /// factors, asset tags etc.
-pub trait KnownState: Debug + StrictDumb + StrictEncode + StrictDecode + Ord + Clone {}
+pub trait KnownState: Debug + StrictDumb + StrictEncode + StrictDecode + Eq + Clone {}
 impl<S: ExposedState> KnownState for S {}
 
 impl KnownState for () {}

--- a/src/contract/contract.rs
+++ b/src/contract/contract.rs
@@ -101,7 +101,7 @@ impl<S: ExposedState> KnownState for S {}
 impl KnownState for () {}
 impl KnownState for DataState {}
 
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Display, From)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Display, From)]
 #[derive(StrictType, StrictDumb, StrictEncode, StrictDecode)]
 #[strict_type(lib = LIB_NAME_RGB, tags = custom)]
 #[cfg_attr(

--- a/src/contract/contract.rs
+++ b/src/contract/contract.rs
@@ -34,10 +34,10 @@ use amplify::hex;
 use strict_encoding::{StrictDecode, StrictDumb, StrictEncode};
 
 use crate::{
-    Assign, AssignmentType, Assignments, AssignmentsRef, ContractId, ExposedSeal, ExposedState,
-    Extension, Genesis, GlobalStateType, OpId, Operation, RevealedAttach, RevealedData,
-    RevealedValue, SchemaId, SubSchema, Transition, TypedAssigns, VoidState, WitnessAnchor,
-    WitnessId, XChain, XOutputSeal, LIB_NAME_RGB,
+    Assign, AssignmentType, Assignments, AssignmentsRef, ContractId, DataState, ExposedSeal,
+    ExposedState, Extension, Genesis, GlobalStateType, OpId, Operation, RevealedAttach,
+    RevealedData, RevealedValue, SchemaId, SubSchema, Transition, TypedAssigns, VoidState,
+    WitnessAnchor, WitnessId, XChain, XOutputSeal, LIB_NAME_RGB,
 };
 
 #[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug, Display)]
@@ -97,6 +97,9 @@ impl FromStr for Opout {
 /// factors, asset tags etc.
 pub trait KnownState: Debug + StrictDumb + StrictEncode + StrictDecode + Ord + Clone {}
 impl<S: ExposedState> KnownState for S {}
+
+impl KnownState for () {}
+impl KnownState for DataState {}
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Display, From)]
 #[derive(StrictType, StrictDumb, StrictEncode, StrictDecode)]

--- a/src/contract/data.rs
+++ b/src/contract/data.rs
@@ -71,6 +71,10 @@ impl Conceal for VoidState {
 pub struct DataState(SmallBlob);
 impl StrictSerialize for DataState {}
 
+impl From<RevealedData> for DataState {
+    fn from(data: RevealedData) -> Self { data.value }
+}
+
 #[derive(Clone, Eq, PartialEq, Hash)]
 #[derive(StrictType, StrictDumb, StrictEncode, StrictDecode)]
 #[strict_type(lib = LIB_NAME_RGB)]

--- a/src/contract/data.rs
+++ b/src/contract/data.rs
@@ -27,6 +27,7 @@ use std::io::Write;
 use amplify::confinement::SmallBlob;
 use amplify::hex::ToHex;
 use amplify::{Bytes32, Wrapper};
+use bp::secp256k1::rand::{random, Rng, RngCore};
 use commit_verify::{CommitEncode, CommitVerify, Conceal, StrictEncodedProtocol};
 use strict_encoding::{StrictSerialize, StrictType};
 
@@ -77,6 +78,26 @@ impl StrictSerialize for DataState {}
 pub struct RevealedData {
     pub value: DataState,
     pub salt: u128,
+}
+
+impl RevealedData {
+    /// Constructs new state using the provided value using random blinding
+    /// factor.
+    pub fn new_random_salt(value: impl Into<DataState>) -> Self { Self::with_salt(value, random()) }
+
+    /// Constructs new state using the provided value and random generator for
+    /// creating blinding factor.
+    pub fn with_rng<R: Rng + RngCore>(value: impl Into<DataState>, rng: &mut R) -> Self {
+        Self::with_salt(value, rng.gen())
+    }
+
+    /// Convenience constructor.
+    pub fn with_salt(value: impl Into<DataState>, salt: u128) -> Self {
+        Self {
+            value: value.into(),
+            salt,
+        }
+    }
 }
 
 impl ExposedState for RevealedData {

--- a/src/contract/data.rs
+++ b/src/contract/data.rs
@@ -20,12 +20,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use core::fmt::{self, Debug, Display, Formatter};
+use core::fmt::{self, Debug, Formatter};
+use std::cmp::Ordering;
+use std::io::Write;
 
-use amplify::confinement::SmallVec;
+use amplify::confinement::SmallBlob;
 use amplify::hex::ToHex;
 use amplify::{Bytes32, Wrapper};
-use commit_verify::{CommitVerify, Conceal, StrictEncodedProtocol};
+use commit_verify::{CommitEncode, CommitVerify, Conceal, StrictEncodedProtocol};
 use strict_encoding::{StrictSerialize, StrictType};
 
 use super::{ConfidentialState, ExposedState};
@@ -57,13 +59,25 @@ impl Conceal for VoidState {
     fn conceal(&self) -> Self::Concealed { *self }
 }
 
-#[derive(Wrapper, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, From)]
-#[derive(StrictType, StrictDumb, StrictEncode, StrictDecode)]
+#[derive(Wrapper, Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash, From, Display, Default)]
+#[display(LowerHex)]
+#[wrapper(Deref, AsSlice, BorrowSlice, Hex)]
+#[derive(StrictType, StrictEncode, StrictDecode)]
 #[strict_type(lib = LIB_NAME_RGB)]
 #[derive(CommitEncode)]
-#[commit_encode(conceal)]
+#[commit_encode(strategy = strict)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(crate = "serde_crate"))]
-pub struct RevealedData(SmallVec<u8>);
+pub struct DataState(SmallBlob);
+impl StrictSerialize for DataState {}
+
+#[derive(Clone, Eq, PartialEq, Hash)]
+#[derive(StrictType, StrictDumb, StrictEncode, StrictDecode)]
+#[strict_type(lib = LIB_NAME_RGB)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize), serde(crate = "serde_crate"))]
+pub struct RevealedData {
+    pub value: DataState,
+    pub salt: u128,
+}
 
 impl ExposedState for RevealedData {
     type Confidential = ConcealedData;
@@ -73,24 +87,39 @@ impl ExposedState for RevealedData {
 
 impl Conceal for RevealedData {
     type Concealed = ConcealedData;
+
     fn conceal(&self) -> Self::Concealed { ConcealedData::commit(self) }
 }
 
-impl StrictSerialize for RevealedData {}
-
-impl Debug for RevealedData {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let val = match String::from_utf8(self.0.to_inner()) {
-            Ok(s) => s,
-            Err(_) => self.0.to_hex(),
-        };
-
-        f.debug_tuple("RevealedData").field(&val).finish()
+impl CommitEncode for RevealedData {
+    fn commit_encode(&self, e: &mut impl Write) {
+        e.write_all(&self.value).ok();
+        e.write_all(&self.salt.to_le_bytes()).ok();
     }
 }
 
-impl Display for RevealedData {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result { f.write_str(&self.as_ref().to_hex()) }
+impl PartialOrd for RevealedData {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> { Some(self.cmp(other)) }
+}
+
+impl Ord for RevealedData {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self.value.cmp(&other.value) {
+            Ordering::Equal => self.salt.cmp(&other.salt),
+            other => other,
+        }
+    }
+}
+
+impl Debug for RevealedData {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let val = String::from_utf8(self.value.to_vec()).unwrap_or_else(|_| self.value.to_hex());
+
+        f.debug_struct("RevealedData")
+            .field("value", &val)
+            .field("salt", &self.salt)
+            .finish()
+    }
 }
 
 /// Confidential version of an structured state data.

--- a/src/contract/fungible.rs
+++ b/src/contract/fungible.rs
@@ -290,7 +290,7 @@ impl RevealedValue {
 
     /// Constructs new state using the provided value and random generator for
     /// creating blinding factor.
-    pub fn with_random_blinding<R: Rng + RngCore>(
+    pub fn with_rng<R: Rng + RngCore>(
         value: impl Into<FungibleState>,
         rng: &mut R,
         tag: AssetTag,
@@ -531,7 +531,7 @@ mod test {
     fn commitments_determinism() {
         let tag = AssetTag::from_byte_array([1u8; 32]);
 
-        let value = RevealedValue::with_random_blinding(15, &mut thread_rng(), tag);
+        let value = RevealedValue::with_rng(15, &mut thread_rng(), tag);
 
         let generators = (0..10)
             .map(|_| {
@@ -548,15 +548,11 @@ mod test {
         let mut r = thread_rng();
         let tag = AssetTag::from_byte_array([1u8; 32]);
 
-        let a = PedersenCommitment::commit(&RevealedValue::with_random_blinding(15, &mut r, tag))
-            .into_inner();
-        let b = PedersenCommitment::commit(&RevealedValue::with_random_blinding(7, &mut r, tag))
-            .into_inner();
+        let a = PedersenCommitment::commit(&RevealedValue::with_rng(15, &mut r, tag)).into_inner();
+        let b = PedersenCommitment::commit(&RevealedValue::with_rng(7, &mut r, tag)).into_inner();
 
-        let c = PedersenCommitment::commit(&RevealedValue::with_random_blinding(13, &mut r, tag))
-            .into_inner();
-        let d = PedersenCommitment::commit(&RevealedValue::with_random_blinding(9, &mut r, tag))
-            .into_inner();
+        let c = PedersenCommitment::commit(&RevealedValue::with_rng(13, &mut r, tag)).into_inner();
+        let d = PedersenCommitment::commit(&RevealedValue::with_rng(9, &mut r, tag)).into_inner();
 
         assert!(!secp256k1_zkp::verify_commitments_sum_to_equal(SECP256K1, &[a, b], &[c, d]))
     }

--- a/src/contract/mod.rs
+++ b/src/contract/mod.rs
@@ -42,8 +42,7 @@ pub use assignments::{
 pub use attachment::{AttachId, ConcealedAttach, RevealedAttach};
 pub use bundle::{BundleId, TransitionBundle, Vin};
 pub use contract::{
-    AttachOutput, ContractHistory, ContractState, DataOutput, FungibleOutput, GlobalOrd, Opout,
-    OpoutParseError, OutputAssignment, RightsOutput,
+    ContractHistory, ContractState, GlobalOrd, KnownState, Opout, OpoutParseError, OutputAssignment,
 };
 pub use data::{ConcealedData, RevealedData, VoidState};
 pub use fungible::{

--- a/src/contract/mod.rs
+++ b/src/contract/mod.rs
@@ -45,7 +45,7 @@ pub use contract::{
     AssignmentWitness, ContractHistory, ContractState, GlobalOrd, KnownState, Opout,
     OpoutParseError, OutputAssignment,
 };
-pub use data::{ConcealedData, RevealedData, VoidState};
+pub use data::{ConcealedData, DataState, RevealedData, VoidState};
 pub use fungible::{
     AssetTag, BlindingFactor, BlindingParseError, ConcealedValue, FungibleState,
     InvalidFieldElement, NoiseDumb, PedersenCommitment, RangeProof, RangeProofError, RevealedValue,

--- a/src/contract/mod.rs
+++ b/src/contract/mod.rs
@@ -42,7 +42,8 @@ pub use assignments::{
 pub use attachment::{AttachId, ConcealedAttach, RevealedAttach};
 pub use bundle::{BundleId, TransitionBundle, Vin};
 pub use contract::{
-    ContractHistory, ContractState, GlobalOrd, KnownState, Opout, OpoutParseError, OutputAssignment,
+    AssignmentWitness, ContractHistory, ContractState, GlobalOrd, KnownState, Opout,
+    OpoutParseError, OutputAssignment,
 };
 pub use data::{ConcealedData, RevealedData, VoidState};
 pub use fungible::{

--- a/src/stl.rs
+++ b/src/stl.rs
@@ -32,7 +32,7 @@ use crate::{AnchoredBundle, ContractState, Extension, Genesis, SubSchema, LIB_NA
 
 /// Strict types id for the library providing data types for RGB consensus.
 pub const LIB_ID_RGB: &str =
-    "urn:ubideco:stl:2PcZtrPrfQCu27qw8b4Wz4cEqUn2PpgSkDHwF4qVyyrq#russian-child-member";
+    "urn:ubideco:stl:3VRk6Jd3VaDKff4gYasqFSCvq5xzLygbRunhhGJbF7Bh#boston-pony-goblin";
 
 fn _rgb_core_stl() -> Result<TypeLib, CompileError> {
     LibBuilder::new(libname!(LIB_NAME_RGB), tiny_bset! {

--- a/src/stl.rs
+++ b/src/stl.rs
@@ -32,7 +32,7 @@ use crate::{AnchoredBundle, ContractState, Extension, Genesis, SubSchema, LIB_NA
 
 /// Strict types id for the library providing data types for RGB consensus.
 pub const LIB_ID_RGB: &str =
-    "urn:ubideco:stl:3VRk6Jd3VaDKff4gYasqFSCvq5xzLygbRunhhGJbF7Bh#boston-pony-goblin";
+    "urn:ubideco:stl:141hHBYBr2mzKyskZbRuwazYC9ki5x9ZrrzQHLbgBzx#oscar-rufus-tractor";
 
 fn _rgb_core_stl() -> Result<TypeLib, CompileError> {
     LibBuilder::new(libname!(LIB_NAME_RGB), tiny_bset! {

--- a/src/validation/logic.rs
+++ b/src/validation/logic.rs
@@ -260,7 +260,7 @@ impl<Root: SchemaRoot> Schema<Root> {
             for data in set {
                 if self
                     .type_system
-                    .strict_deserialize_type(*sem_id, data.as_ref())
+                    .strict_deserialize_type(*sem_id, data.value.as_ref())
                     .is_err()
                 {
                     status.add_failure(validation::Failure::SchemaInvalidGlobalValue(

--- a/src/validation/state.rs
+++ b/src/validation/state.rs
@@ -98,7 +98,7 @@ impl StateSchema {
                     (StateSchema::Fungible(_), StateData::Fungible(_)) => {}
                     (StateSchema::Structured(sem_id), StateData::Structured(data)) => {
                         if type_system
-                            .strict_deserialize_type(*sem_id, data.as_ref())
+                            .strict_deserialize_type(*sem_id, data.value.as_ref())
                             .is_err()
                         {
                             status.add_failure(validation::Failure::SchemaInvalidOwnedValue(

--- a/src/vm/op_contract.rs
+++ b/src/vm/op_contract.rs
@@ -260,7 +260,7 @@ impl InstructionSet for ContractOp {
                 else {
                     fail!()
                 };
-                let state = state.map(|s| s.to_inner());
+                let state = state.map(|s| s.value.as_inner());
                 regs.set_s(*reg, state);
             }
             ContractOp::LdS(state_type, index, reg) => {
@@ -271,7 +271,7 @@ impl InstructionSet for ContractOp {
                 else {
                     fail!()
                 };
-                let state = state.map(|s| s.to_inner());
+                let state = state.map(|s| s.value.into_inner());
                 regs.set_s(*reg, state);
             }
             ContractOp::LdF(state_type, index, reg) => {
@@ -292,7 +292,7 @@ impl InstructionSet for ContractOp {
                 else {
                     fail!()
                 };
-                regs.set_s(*reg, Some(state.as_inner()));
+                regs.set_s(*reg, Some(state.value.as_inner()));
             }
             ContractOp::LdC(_state_type, _index, _reg) => {
                 // TODO: implement global contract state
@@ -321,11 +321,11 @@ impl InstructionSet for ContractOp {
                 if sum.len() != 1 {
                     fail!()
                 }
-                if sum[0].as_inner().len() != 8 {
+                if sum[0].value.as_inner().len() != 8 {
                     fail!()
                 }
                 let mut bytes = [0u8; 8];
-                bytes.copy_from_slice(sum[0].as_inner());
+                bytes.copy_from_slice(sum[0].value.as_inner());
                 let sum = u64::from_le_bytes(bytes);
 
                 let Some(tag) = context.asset_tags.get(owned_state) else {


### PR DESCRIPTION
- Add blinding to data types
- Make function names and signatures working with blinding factors more consistent
- Separate state which contains blinding information from the state which doesn't
- Provide a trait for non-blinded state (`KnownState`)

Prerequisite for https://github.com/RGB-WG/rgb-std/pull/126 and https://github.com/RGB-WG/rgb/pull/92