### PR TITLE
AssetTag compatible with wasm target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,6 +605,7 @@ dependencies = [
  "amplify",
  "baid58",
  "bp-core",
+ "chrono",
  "commit_verify",
  "getrandom",
  "mime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ secp256k1-zkp = { version = "0.9.2", features = ["rand", "rand-std", "global-con
 baid58 = "~0.4.4"
 mime = "~0.3.17"
 serde_crate = { package = "serde", version = "1", features = ["derive"], optional = true }
+chrono = "0.4.31"
 
 [features]
 default = []


### PR DESCRIPTION
**Description**

This PR intent fix `Asset Tag` initialization to **wasm** target compilation. 

When we try issuing a new contract with wasm target, the builder crashes on **AssetTag** initialization. I changed `std::time::SystemTime` to `chrono::Local`.

CC @cryptoquick 