### PR TITLE
Add contract global state in VM

### DIFF
--- a/src/validation/logic.rs
+++ b/src/validation/logic.rs
@@ -39,6 +39,7 @@ impl<Root: SchemaRoot> Schema<Root> {
         &'validator self,
         consignment: &'validator CheckedConsignment<'consignment, C>,
         op: OpRef,
+        globals: &'consignment GlobalState,
         vm: &'consignment dyn VirtualMachine,
     ) -> validation::Status {
         let id = op.id();
@@ -168,6 +169,7 @@ impl<Root: SchemaRoot> Schema<Root> {
             consignment.genesis().contract_id(),
             id,
             self.subset_of.is_some(),
+            globals,
             &op,
             &prev_state,
             &redeemed,
@@ -426,7 +428,7 @@ impl<Root: SchemaRoot> Schema<Root> {
     }
 }
 
-pub struct OpInfo<'op> {
+pub struct OpInfo<'contract, 'op> {
     pub subschema: bool,
     pub contract_id: ContractId,
     pub id: OpId,
@@ -437,14 +439,16 @@ pub struct OpInfo<'op> {
     pub owned_state: AssignmentsRef<'op>,
     pub redeemed: &'op Valencies,
     pub valencies: &'op Valencies,
-    pub global: &'op GlobalState,
+    pub op_global: &'op GlobalState,
+    pub contract_global: &'contract GlobalState,
 }
 
-impl<'op> OpInfo<'op> {
+impl<'contract, 'op> OpInfo<'contract, 'op> {
     pub fn with(
         contract_id: ContractId,
         id: OpId,
         subschema: bool,
+        globals: &'contract GlobalState,
         op: &'op OpRef<'op>,
         prev_state: &'op Assignments<GraphSeal>,
         redeemed: &'op Valencies,
@@ -461,7 +465,8 @@ impl<'op> OpInfo<'op> {
             owned_state: op.assignments(),
             redeemed,
             valencies: op.valencies(),
-            global: op.globals(),
+            op_global: op.globals(),
+            contract_global: globals,
         }
     }
 }

--- a/src/vm/isa.rs
+++ b/src/vm/isa.rs
@@ -46,7 +46,7 @@ pub enum RgbIsa {
 }
 
 impl InstructionSet for RgbIsa {
-    type Context<'ctx> = OpInfo<'ctx>;
+    type Context<'ctx> = OpInfo<'ctx, 'ctx>;
 
     fn isa_ids() -> BTreeSet<&'static str> {
         bset! {"RGB"}

--- a/src/vm/op_contract.rs
+++ b/src/vm/op_contract.rs
@@ -153,7 +153,7 @@ pub enum ContractOp {
 }
 
 impl InstructionSet for ContractOp {
-    type Context<'ctx> = OpInfo<'ctx>;
+    type Context<'ctx> = OpInfo<'ctx, 'ctx>;
 
     fn isa_ids() -> BTreeSet<&'static str> { none!() }
 
@@ -246,7 +246,7 @@ impl InstructionSet for ContractOp {
                 );
             }
             ContractOp::CnG(state_type, reg) => {
-                regs.set_n(RegA::A16, *reg, context.global.get(state_type).map(|a| a.len_u16()));
+                regs.set_n(RegA::A16, *reg, context.op_global.get(state_type).map(|a| a.len_u16()));
             }
             ContractOp::CnC(_state_type, _reg) => {
                 // TODO: implement global contract state
@@ -286,7 +286,7 @@ impl InstructionSet for ContractOp {
             }
             ContractOp::LdG(state_type, index, reg) => {
                 let Some(state) = context
-                    .global
+                    .op_global
                     .get(state_type)
                     .and_then(|a| a.get(*index as usize))
                 else {
@@ -315,7 +315,7 @@ impl InstructionSet for ContractOp {
             }
 
             ContractOp::PcCs(owned_state, global_state) => {
-                let Some(sum) = context.global.get(global_state) else {
+                let Some(sum) = context.op_global.get(global_state) else {
                     fail!()
                 };
                 if sum.len() != 1 {

--- a/src/vm/runtime.rs
+++ b/src/vm/runtime.rs
@@ -60,7 +60,7 @@ impl<'script> AluRuntime<'script> {
             }
         }
 
-        for ty in info.global.keys() {
+        for ty in info.op_global.keys() {
             regs.nums
                 .insert((RegAFR::A(RegA::A16), Reg32::Reg1), ty.into_inner().into());
             self.run(EntryPoint::ValidateGlobalState(*ty), &regs, info)?;


### PR DESCRIPTION
This is WIP on adding contract state (not just operation state, but whole contract state) to the VM required for https://github.com/RGB-WG/rgb-core/pull/201

It seems like this will require refactoring of the validation workflow, since now we must evaluate the contract state not in stdlib, but right during the validation procedure itself...

I think it will be nice to postpone this until v0.12

NB: this is WIP since the global state for the contract IS NOT COMPUTED, i.e. validator always sees an empty contract state.