### PR TITLE
Support new AluVM serde human-readable serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,4 +59,4 @@ getrandom = { version = "0.2", features = ["js"] }
 wasm-bindgen-test = "0.3"
 
 [package.metadata.docs.rs]
-features = [ "all" ]
+features = ["all"]

--- a/src/vm/mod.rs
+++ b/src/vm/mod.rs
@@ -38,4 +38,4 @@ pub use isa::RgbIsa;
 pub use op_contract::ContractOp;
 pub use op_timechain::TimechainOp;
 pub use runtime::AluRuntime;
-pub use script::{AluLib, AluScript, EntryPoint, LIBS_MAX_TOTAL};
+pub use script::{AluScript, EntryPoint, LIBS_MAX_TOTAL};


### PR DESCRIPTION
This removes serialization of AluVM code in form of assembly and instead serializes it as a hexadecimal string