### PR TITLE
Make VM opcodes sufficient for inflationary assets

### DIFF
--- a/src/vm/macroasm.rs
+++ b/src/vm/macroasm.rs
@@ -34,8 +34,9 @@ macro_rules! rgbasm {
 
 #[macro_export]
 macro_rules! isa_instr {
-    (pcvs $no:literal) => {{ RgbIsa::Contract(ContractOp::PcVs($no.into())) }};
-    (pccs $no1:literal, $no2:literal) => {{ RgbIsa::Contract(ContractOp::PcCs($no1.into(), $no2.into())) }};
+    (pcvs $no:literal) => {{ RgbIsa::Contract(ContractOp::Pcvs($no.into())) }};
+    (pcas $no:literal) => {{ RgbIsa::Contract(ContractOp::Pcas($no.into())) }};
+    (pcps $no:literal) => {{ RgbIsa::Contract(ContractOp::Pcps($no.into())) }};
     (cng $t:literal,a8[$a_idx:literal]) => {{ RgbIsa::Contract(ContractOp::CnG($t.into(), Reg32::from(u5::with($a_idx)))) }};
     (cnc $t:literal,a16[$a_idx:literal]) => {{ RgbIsa::Contract(ContractOp::CnC($t.into(), Reg32::from(u5::with($a_idx)))) }};
     (ldg $t:literal,a8[$a_idx:literal],s16[$s_idx:literal]) => {{

--- a/src/vm/macroasm.rs
+++ b/src/vm/macroasm.rs
@@ -24,7 +24,6 @@
 macro_rules! rgbasm {
     ($( $tt:tt )+) => {{ #[allow(unused_imports)] {
         use amplify::num::{u4, u5};
-        use $crate::{AssignmentType, GlobalStateType, MetaType};
         use $crate::vm::{RgbIsa, ContractOp, TimechainOp};
         use $crate::vm::aluasm_isa;
         use $crate::isa_instr;
@@ -34,38 +33,14 @@ macro_rules! rgbasm {
 
 #[macro_export]
 macro_rules! isa_instr {
-    (pcvs $no:ident) => {{ RgbIsa::Contract(ContractOp::Pcvs($no.into())) }};
-    (pcas $no:ident) => {{ RgbIsa::Contract(ContractOp::Pcas($no.into())) }};
-    (pcps $no:ident) => {{ RgbIsa::Contract(ContractOp::Pcps($no.into())) }};
-    (cng $t:ident,a8[$a_idx:literal]) => {{ RgbIsa::Contract(ContractOp::CnG($t.into(), Reg32::from(u5::with($a_idx)))) }};
-    (cnc $t:ident,a16[$a_idx:literal]) => {{ RgbIsa::Contract(ContractOp::CnC($t.into(), Reg32::from(u5::with($a_idx)))) }};
-    (ldm $t:ident,a8[$a_idx:literal],s16[$s_idx:literal]) => {{
-        RgbIsa::Contract(ContractOp::LdM(
-            MetaType::from($t as u16),
-            Reg16::from(u4::with($a_idx)),
-            RegS::from($s_idx),
-        ))
-    }};
-    (ldg $t:ident,a8[$a_idx:literal],s16[$s_idx:literal]) => {{
-        RgbIsa::Contract(ContractOp::LdG(
-            GlobalStateType::from($t as u16),
-            Reg16::from(u4::with($a_idx)),
-            RegS::from($s_idx),
-        ))
-    }};
-    (ldp $t:ident,a16[$a_idx:literal],s16[$s_idx:literal]) => {{
-        RgbIsa::Contract(ContractOp::LdP(
-            AssignmentType::from($t as u16),
-            Reg16::from(u4::with($a_idx)),
-            RegS::from($s_idx),
-        ))
-    }};
-    (lds $t:ident,a16[$a_idx:literal],s16[$s_idx:literal]) => {{
-        RgbIsa::Contract(ContractOp::LdS(
-            AssignmentType::from($t as u16),
-            Reg16::from(u4::with($a_idx)),
-            RegS::from($s_idx),
-        ))
-    }};
+    (pcvs $no:ident) => {{ RgbIsa::Contract(ContractOp::Pcvs($no)) }};
+    (pcas $no:ident) => {{ RgbIsa::Contract(ContractOp::Pcas($no)) }};
+    (pcps $no:ident) => {{ RgbIsa::Contract(ContractOp::Pcps($no)) }};
+    (cng $t:ident,a8[$a_idx:literal]) => {{ RgbIsa::Contract(ContractOp::CnG($t, Reg32::from(u5::with($a_idx)))) }};
+    (cnc $t:ident,a16[$a_idx:literal]) => {{ RgbIsa::Contract(ContractOp::CnC($t, Reg32::from(u5::with($a_idx)))) }};
+    (ldm $t:ident,a8[$a_idx:literal],s16[$s_idx:literal]) => {{ RgbIsa::Contract(ContractOp::LdM($t, Reg16::from(u4::with($a_idx)), RegS::from($s_idx))) }};
+    (ldg $t:ident,a8[$a_idx:literal],s16[$s_idx:literal]) => {{ RgbIsa::Contract(ContractOp::LdG($t, Reg16::from(u4::with($a_idx)), RegS::from($s_idx))) }};
+    (ldp $t:ident,a16[$a_idx:literal],s16[$s_idx:literal]) => {{ RgbIsa::Contract(ContractOp::LdP($t, Reg16::from(u4::with($a_idx)), RegS::from($s_idx))) }};
+    (lds $t:ident,a16[$a_idx:literal],s16[$s_idx:literal]) => {{ RgbIsa::Contract(ContractOp::LdS($t, Reg16::from(u4::with($a_idx)), RegS::from($s_idx))) }};
     ($op:ident $($tt:tt)+) => {{ compile_error!(concat!("unknown RGB assembly opcode `", stringify!($op), "`")) }};
 }

--- a/src/vm/macroasm.rs
+++ b/src/vm/macroasm.rs
@@ -24,7 +24,7 @@
 macro_rules! rgbasm {
     ($( $tt:tt )+) => {{ #[allow(unused_imports)] {
         use amplify::num::{u4, u5};
-        use $crate::{AssignmentType, GlobalStateType};
+        use $crate::{AssignmentType, GlobalStateType, MetaType};
         use $crate::vm::{RgbIsa, ContractOp, TimechainOp};
         use $crate::vm::aluasm_isa;
         use $crate::isa_instr;
@@ -39,6 +39,13 @@ macro_rules! isa_instr {
     (pcps $no:ident) => {{ RgbIsa::Contract(ContractOp::Pcps($no.into())) }};
     (cng $t:ident,a8[$a_idx:literal]) => {{ RgbIsa::Contract(ContractOp::CnG($t.into(), Reg32::from(u5::with($a_idx)))) }};
     (cnc $t:ident,a16[$a_idx:literal]) => {{ RgbIsa::Contract(ContractOp::CnC($t.into(), Reg32::from(u5::with($a_idx)))) }};
+    (ldm $t:ident,a8[$a_idx:literal],s16[$s_idx:literal]) => {{
+        RgbIsa::Contract(ContractOp::LdM(
+            MetaType::from($t as u16),
+            Reg16::from(u4::with($a_idx)),
+            RegS::from($s_idx),
+        ))
+    }};
     (ldg $t:ident,a8[$a_idx:literal],s16[$s_idx:literal]) => {{
         RgbIsa::Contract(ContractOp::LdG(
             GlobalStateType::from($t as u16),

--- a/src/vm/macroasm.rs
+++ b/src/vm/macroasm.rs
@@ -38,7 +38,7 @@ macro_rules! isa_instr {
     (pcps $no:ident) => {{ RgbIsa::Contract(ContractOp::Pcps($no)) }};
     (cng $t:ident,a8[$a_idx:literal]) => {{ RgbIsa::Contract(ContractOp::CnG($t, Reg32::from(u5::with($a_idx)))) }};
     (cnc $t:ident,a16[$a_idx:literal]) => {{ RgbIsa::Contract(ContractOp::CnC($t, Reg32::from(u5::with($a_idx)))) }};
-    (ldm $t:ident,a8[$a_idx:literal],s16[$s_idx:literal]) => {{ RgbIsa::Contract(ContractOp::LdM($t, Reg16::from(u4::with($a_idx)), RegS::from($s_idx))) }};
+    (ldm $t:ident,s16[$s_idx:literal]) => {{ RgbIsa::Contract(ContractOp::LdM($t, RegS::from($s_idx))) }};
     (ldg $t:ident,a8[$a_idx:literal],s16[$s_idx:literal]) => {{ RgbIsa::Contract(ContractOp::LdG($t, Reg16::from(u4::with($a_idx)), RegS::from($s_idx))) }};
     (ldp $t:ident,a16[$a_idx:literal],s16[$s_idx:literal]) => {{ RgbIsa::Contract(ContractOp::LdP($t, Reg16::from(u4::with($a_idx)), RegS::from($s_idx))) }};
     (lds $t:ident,a16[$a_idx:literal],s16[$s_idx:literal]) => {{ RgbIsa::Contract(ContractOp::LdS($t, Reg16::from(u4::with($a_idx)), RegS::from($s_idx))) }};

--- a/src/vm/macroasm.rs
+++ b/src/vm/macroasm.rs
@@ -34,26 +34,26 @@ macro_rules! rgbasm {
 
 #[macro_export]
 macro_rules! isa_instr {
-    (pcvs $no:literal) => {{ RgbIsa::Contract(ContractOp::Pcvs($no.into())) }};
-    (pcas $no:literal) => {{ RgbIsa::Contract(ContractOp::Pcas($no.into())) }};
-    (pcps $no:literal) => {{ RgbIsa::Contract(ContractOp::Pcps($no.into())) }};
-    (cng $t:literal,a8[$a_idx:literal]) => {{ RgbIsa::Contract(ContractOp::CnG($t.into(), Reg32::from(u5::with($a_idx)))) }};
-    (cnc $t:literal,a16[$a_idx:literal]) => {{ RgbIsa::Contract(ContractOp::CnC($t.into(), Reg32::from(u5::with($a_idx)))) }};
-    (ldg $t:literal,a8[$a_idx:literal],s16[$s_idx:literal]) => {{
+    (pcvs $no:ident) => {{ RgbIsa::Contract(ContractOp::Pcvs($no.into())) }};
+    (pcas $no:ident) => {{ RgbIsa::Contract(ContractOp::Pcas($no.into())) }};
+    (pcps $no:ident) => {{ RgbIsa::Contract(ContractOp::Pcps($no.into())) }};
+    (cng $t:ident,a8[$a_idx:literal]) => {{ RgbIsa::Contract(ContractOp::CnG($t.into(), Reg32::from(u5::with($a_idx)))) }};
+    (cnc $t:ident,a16[$a_idx:literal]) => {{ RgbIsa::Contract(ContractOp::CnC($t.into(), Reg32::from(u5::with($a_idx)))) }};
+    (ldg $t:ident,a8[$a_idx:literal],s16[$s_idx:literal]) => {{
         RgbIsa::Contract(ContractOp::LdG(
             GlobalStateType::from($t as u16),
             Reg16::from(u4::with($a_idx)),
             RegS::from($s_idx),
         ))
     }};
-    (ldp $t:literal,a16[$a_idx:literal],s16[$s_idx:literal]) => {{
+    (ldp $t:ident,a16[$a_idx:literal],s16[$s_idx:literal]) => {{
         RgbIsa::Contract(ContractOp::LdP(
             AssignmentType::from($t as u16),
             Reg16::from(u4::with($a_idx)),
             RegS::from($s_idx),
         ))
     }};
-    (lds $t:literal,a16[$a_idx:literal],s16[$s_idx:literal]) => {{
+    (lds $t:ident,a16[$a_idx:literal],s16[$s_idx:literal]) => {{
         RgbIsa::Contract(ContractOp::LdS(
             AssignmentType::from($t as u16),
             Reg16::from(u4::with($a_idx)),

--- a/src/vm/op_contract.rs
+++ b/src/vm/op_contract.rs
@@ -156,7 +156,7 @@ pub enum ContractOp {
     /// If verification succeeds, doesn't change `st0` value; otherwise sets it
     /// to `false` and stops execution.
     #[display("pcis    {0}")]
-    Pcis(/** owned state type */ AssignmentType),
+    Pcps(/** owned state type */ AssignmentType),
 
     /// All other future unsupported operations, which must set `st0` to
     /// `false` and stop the execution.
@@ -183,7 +183,7 @@ impl InstructionSet for ContractOp {
             ContractOp::CnC(_, _) |
             ContractOp::LdM(_, _) => bset![],
             ContractOp::Pcvs(_) => bset![],
-            ContractOp::Pcas(_) | ContractOp::Pcis(_) => bset![Reg::A(RegA::A64, Reg32::Reg0)],
+            ContractOp::Pcas(_) | ContractOp::Pcps(_) => bset![Reg::A(RegA::A64, Reg32::Reg0)],
             ContractOp::Fail(_) => bset![],
         }
     }
@@ -206,7 +206,7 @@ impl InstructionSet for ContractOp {
             ContractOp::LdM(_, reg) => {
                 bset![Reg::S(*reg)]
             }
-            ContractOp::Pcvs(_) | ContractOp::Pcas(_) | ContractOp::Pcis(_) => {
+            ContractOp::Pcvs(_) | ContractOp::Pcas(_) | ContractOp::Pcps(_) => {
                 bset![]
             }
             ContractOp::Fail(_) => bset![],
@@ -226,7 +226,7 @@ impl InstructionSet for ContractOp {
             ContractOp::LdC(_, _, _) => 8,
             ContractOp::LdM(_, _) => 6,
             ContractOp::Pcvs(_) => 1024,
-            ContractOp::Pcas(_) | ContractOp::Pcis(_) => 512,
+            ContractOp::Pcas(_) | ContractOp::Pcps(_) => 512,
             ContractOp::Fail(_) => u64::MAX,
         }
     }
@@ -406,7 +406,7 @@ impl InstructionSet for ContractOp {
                 }
             }
 
-            ContractOp::Pcis(owned_state) => {
+            ContractOp::Pcps(owned_state) => {
                 let Some(sum) = *regs.get_n(RegA::A64, Reg32::Reg0) else {
                     fail!()
                 };
@@ -474,7 +474,7 @@ impl Bytecode for ContractOp {
 
             ContractOp::Pcvs(_) => INSTR_PCVS,
             ContractOp::Pcas(_) => INSTR_PCAS,
-            ContractOp::Pcis(_) => INSTR_PCIS,
+            ContractOp::Pcps(_) => INSTR_PCPS,
 
             ContractOp::Fail(other) => *other,
         }
@@ -536,7 +536,7 @@ impl Bytecode for ContractOp {
 
             ContractOp::Pcvs(state_type) => writer.write_u16(*state_type)?,
             ContractOp::Pcas(owned_type) => writer.write_u16(*owned_type)?,
-            ContractOp::Pcis(owned_type) => writer.write_u16(*owned_type)?,
+            ContractOp::Pcps(owned_type) => writer.write_u16(*owned_type)?,
 
             ContractOp::Fail(_) => {}
         }
@@ -603,7 +603,7 @@ impl Bytecode for ContractOp {
 
             INSTR_PCVS => Self::Pcvs(reader.read_u16()?.into()),
             INSTR_PCAS => Self::Pcas(reader.read_u16()?.into()),
-            INSTR_PCIS => Self::Pcis(reader.read_u16()?.into()),
+            INSTR_PCPS => Self::Pcps(reader.read_u16()?.into()),
 
             x => Self::Fail(x),
         })

--- a/src/vm/op_contract.rs
+++ b/src/vm/op_contract.rs
@@ -128,7 +128,7 @@ pub enum ContractOp {
     /// If verification succeeds, doesn't change `st0` value; otherwise sets it
     /// to `false` and stops execution.
     #[display("pcvs    {0}")]
-    PcVs(AssignmentType),
+    Pcvs(AssignmentType),
 
     /// Verifies equivalence of a sum of pedersen commitments for the list of
     /// assignment outputs to a value from `a64[0]` register.
@@ -142,7 +142,21 @@ pub enum ContractOp {
     /// If verification succeeds, doesn't change `st0` value; otherwise sets it
     /// to `false` and stops execution.
     #[display("pcas    {0}")]
-    PcAs(/** owned state type */ AssignmentType),
+    Pcas(/** owned state type */ AssignmentType),
+
+    /// Verifies equivalence of a sum of pedersen commitments for the list of
+    /// inputs to a value from `a64[0]` register.
+    ///
+    /// The first argument specifies owned state type for the sum operation. If
+    /// this state does not exist, or either inputs or outputs does not have
+    /// any data for the state, the verification fails.
+    ///
+    /// If `a64[0]` register does not contain value, the verification fails.
+    ///
+    /// If verification succeeds, doesn't change `st0` value; otherwise sets it
+    /// to `false` and stops execution.
+    #[display("pcis    {0}")]
+    Pcis(/** owned state type */ AssignmentType),
 
     /// All other future unsupported operations, which must set `st0` to
     /// `false` and stop the execution.
@@ -168,8 +182,8 @@ impl InstructionSet for ContractOp {
             ContractOp::CnG(_, _) |
             ContractOp::CnC(_, _) |
             ContractOp::LdM(_, _) => bset![],
-            ContractOp::PcVs(_) => bset![],
-            ContractOp::PcAs(_) => bset![Reg::A(RegA::A64, Reg32::Reg0)],
+            ContractOp::Pcvs(_) => bset![],
+            ContractOp::Pcas(_) | ContractOp::Pcis(_) => bset![Reg::A(RegA::A64, Reg32::Reg0)],
             ContractOp::Fail(_) => bset![],
         }
     }
@@ -192,7 +206,7 @@ impl InstructionSet for ContractOp {
             ContractOp::LdM(_, reg) => {
                 bset![Reg::S(*reg)]
             }
-            ContractOp::PcVs(_) | ContractOp::PcAs(_) => {
+            ContractOp::Pcvs(_) | ContractOp::Pcas(_) | ContractOp::Pcis(_) => {
                 bset![]
             }
             ContractOp::Fail(_) => bset![],
@@ -211,8 +225,8 @@ impl InstructionSet for ContractOp {
             ContractOp::LdG(_, _, _) |
             ContractOp::LdC(_, _, _) => 8,
             ContractOp::LdM(_, _) => 6,
-            ContractOp::PcVs(_) => 512,
-            ContractOp::PcAs(_) => 1024,
+            ContractOp::Pcvs(_) => 1024,
+            ContractOp::Pcas(_) | ContractOp::Pcis(_) => 512,
             ContractOp::Fail(_) => u64::MAX,
         }
     }
@@ -357,7 +371,7 @@ impl InstructionSet for ContractOp {
                 regs.set_s(*reg, Some(meta.to_inner()));
             }
 
-            ContractOp::PcVs(state_type) => {
+            ContractOp::Pcvs(state_type) => {
                 let inputs = load_inputs!(state_type);
                 let outputs = load_outputs!(state_type);
                 if !secp256k1_zkp::verify_commitments_sum_to_equal(
@@ -369,7 +383,7 @@ impl InstructionSet for ContractOp {
                 }
             }
 
-            ContractOp::PcAs(owned_state) => {
+            ContractOp::Pcas(owned_state) => {
                 let Some(sum) = *regs.get_n(RegA::A64, Reg32::Reg0) else {
                     fail!()
                 };
@@ -392,6 +406,28 @@ impl InstructionSet for ContractOp {
                 }
             }
 
+            ContractOp::Pcis(owned_state) => {
+                let Some(sum) = *regs.get_n(RegA::A64, Reg32::Reg0) else {
+                    fail!()
+                };
+                let sum = u64::from(sum);
+
+                let Some(tag) = context.asset_tags.get(owned_state) else {
+                    fail!()
+                };
+                let sum = RevealedValue::with_blinding(sum, BlindingFactor::EMPTY, *tag);
+
+                let inputs = [PedersenCommitment::commit(&sum).into_inner()];
+                let outputs = load_inputs!(owned_state);
+
+                if !secp256k1_zkp::verify_commitments_sum_to_equal(
+                    secp256k1_zkp::SECP256K1,
+                    &inputs,
+                    &outputs,
+                ) {
+                    fail!()
+                }
+            }
             // All other future unsupported operations, which must set `st0` to `false`.
             _ => fail!(),
         }
@@ -414,7 +450,7 @@ impl Bytecode for ContractOp {
             ContractOp::LdG(_, _, _) |
             ContractOp::LdM(_, _) => 4,
 
-            ContractOp::PcVs(_) | ContractOp::PcAs(_) => 3,
+            ContractOp::Pcvs(_) | ContractOp::Pcas(_) | ContractOp::Pcis(_) => 3,
 
             ContractOp::Fail(_) => 1,
         }
@@ -436,8 +472,9 @@ impl Bytecode for ContractOp {
             ContractOp::LdC(_, _, _) => INSTR_LDC,
             ContractOp::LdM(_, _) => INSTR_LDM,
 
-            ContractOp::PcVs(_) => INSTR_PCVS,
-            ContractOp::PcAs(_) => INSTR_PCAS,
+            ContractOp::Pcvs(_) => INSTR_PCVS,
+            ContractOp::Pcas(_) => INSTR_PCAS,
+            ContractOp::Pcis(_) => INSTR_PCIS,
 
             ContractOp::Fail(other) => *other,
         }
@@ -497,10 +534,9 @@ impl Bytecode for ContractOp {
                 writer.write_u4(u4::ZERO)?;
             }
 
-            ContractOp::PcVs(state_type) => writer.write_u16(*state_type)?,
-            ContractOp::PcAs(owned_type) => {
-                writer.write_u16(*owned_type)?;
-            }
+            ContractOp::Pcvs(state_type) => writer.write_u16(*state_type)?,
+            ContractOp::Pcas(owned_type) => writer.write_u16(*owned_type)?,
+            ContractOp::Pcis(owned_type) => writer.write_u16(*owned_type)?,
 
             ContractOp::Fail(_) => {}
         }
@@ -565,8 +601,9 @@ impl Bytecode for ContractOp {
                 i
             }
 
-            INSTR_PCVS => Self::PcVs(reader.read_u16()?.into()),
-            INSTR_PCAS => Self::PcAs(reader.read_u16()?.into()),
+            INSTR_PCVS => Self::Pcvs(reader.read_u16()?.into()),
+            INSTR_PCAS => Self::Pcas(reader.read_u16()?.into()),
+            INSTR_PCIS => Self::Pcis(reader.read_u16()?.into()),
 
             x => Self::Fail(x),
         })
@@ -586,7 +623,7 @@ mod test {
     #[test]
     fn encoding() {
         let code =
-            [Instr::ExtensionCodes(RgbIsa::Contract(ContractOp::PcVs(AssignmentType::from(4000))))];
+            [Instr::ExtensionCodes(RgbIsa::Contract(ContractOp::Pcvs(AssignmentType::from(4000))))];
         let alu_lib = Lib::assemble(&code).unwrap();
         eprintln!("{alu_lib}");
         let alu_id = alu_lib.id();

--- a/src/vm/opcodes.rs
+++ b/src/vm/opcodes.rs
@@ -45,7 +45,7 @@ pub const INSTR_LDM: u8 = 0b11_001_010;
 
 pub const INSTR_PCVS: u8 = 0b11_010_000;
 pub const INSTR_PCAS: u8 = 0b11_010_001;
-pub const INSTR_PCIS: u8 = 0b11_010_010;
+pub const INSTR_PCPS: u8 = 0b11_010_010;
 // Reserved 0b11_010_011
 pub const INSTR_CONTRACT_FROM: u8 = 0b11_000_000;
 pub const INSTR_CONTRACT_TO: u8 = 0b11_010_011;

--- a/src/vm/opcodes.rs
+++ b/src/vm/opcodes.rs
@@ -45,7 +45,7 @@ pub const INSTR_LDM: u8 = 0b11_001_010;
 
 pub const INSTR_PCVS: u8 = 0b11_010_000;
 pub const INSTR_PCAS: u8 = 0b11_010_001;
-// Reserved 0b11_010_010
+pub const INSTR_PCIS: u8 = 0b11_010_010;
 // Reserved 0b11_010_011
 pub const INSTR_CONTRACT_FROM: u8 = 0b11_000_000;
 pub const INSTR_CONTRACT_TO: u8 = 0b11_010_011;

--- a/src/vm/opcodes.rs
+++ b/src/vm/opcodes.rs
@@ -44,7 +44,7 @@ pub const INSTR_LDM: u8 = 0b11_001_010;
 // Reserved 0b11_001_111
 
 pub const INSTR_PCVS: u8 = 0b11_010_000;
-pub const INSTR_PCCS: u8 = 0b11_010_001;
+pub const INSTR_PCAS: u8 = 0b11_010_001;
 // Reserved 0b11_010_010
 // Reserved 0b11_010_011
 pub const INSTR_CONTRACT_FROM: u8 = 0b11_000_000;


### PR DESCRIPTION
My examination had shown that with the way RGB op codes for Pedersen commitments work today it is not possible to do a secondary issue verification. This PR addresses this problem, improving use case flexibility