### PR TITLE
Add prelude stl with stl feature gate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,9 @@ pub mod prelude {
     pub use schema::*;
 
     use super::*;
-    pub use super::{schema, stl, validation, vm};
+    pub use super::{schema, validation, vm};
+    #[cfg(feature = "stl")]
+    pub use super::stl;
 }
 
 pub use prelude::*;


### PR DESCRIPTION
With this fix, the CI can apply to develop with all green(#235), and the ci will easier to use in develop branch.