### PR TITLE
assignmentType to GlobalStateType

### DIFF
--- a/src/vm/op_contract.rs
+++ b/src/vm/op_contract.rs
@@ -59,7 +59,7 @@ pub enum ContractOp {
     /// Counts number of global state items of the provided type in the contract
     /// state and puts the number to the destination `a16` register.
     #[display("cnc     {0},a16{1}")]
-    CnC(AssignmentType, Reg32),
+    CnC(GlobalStateType, Reg32),
 
     /// Loads input (previous) structured state with type id from the first
     /// argument and index from the second argument `a16` register into a


### PR DESCRIPTION
Description: Based on the issue in the https://github.com/RGB-WG/rgb-core/issues/253
I changed the `AssignmentType` to `GlobalStateType` in order to match `CnC(GlobalStateType, Reg32)`
If I missed something, or the logic(type) I fixed is wrong, this PR can be closed.