### PR TITLE
Refactor validation status to match all other API changes

### DIFF
--- a/src/contract/mod.rs
+++ b/src/contract/mod.rs
@@ -68,6 +68,6 @@ pub use seal::{
 };
 pub use state::{ConcealedState, ConfidentialState, ExposedState, RevealedState, StateType};
 pub use xchain::{
-    AltLayer1, AltLayer1Set, XChain, XChainParseError, XOutpoint, XCHAIN_BITCOIN_PREFIX,
-    XCHAIN_LIQUID_PREFIX, Impossible
+    AltLayer1, AltLayer1Set, Impossible, XChain, XChainParseError, XOutpoint,
+    XCHAIN_BITCOIN_PREFIX, XCHAIN_LIQUID_PREFIX,
 };

--- a/src/validation/state.rs
+++ b/src/validation/state.rs
@@ -52,12 +52,12 @@ impl OwnedStateSchema {
                         }
                     }
                     (OwnedStateSchema::Structured(_), ConcealedState::Structured(_)) => {
-                        status.add_info(validation::Info::UncheckableConfidentialState(
+                        status.add_warning(validation::Warning::UncheckableConfidentialState(
                             opid, state_type,
                         ));
                     }
                     (OwnedStateSchema::Attachment(_), ConcealedState::Attachment(_)) => {
-                        status.add_info(validation::Info::UncheckableConfidentialState(
+                        status.add_warning(validation::Warning::UncheckableConfidentialState(
                             opid, state_type,
                         ));
                     }

--- a/src/validation/status.rs
+++ b/src/validation/status.rs
@@ -144,7 +144,7 @@ impl Status {
     pub fn validity(&self) -> Validity {
         if !self.failures.is_empty() {
             Validity::Invalid
-        } else if self.warnings.is_empty() {
+        } else if !self.warnings.is_empty() {
             Validity::Warnings
         } else {
             Validity::Valid

--- a/src/validation/status.rs
+++ b/src/validation/status.rs
@@ -29,7 +29,7 @@ use strict_types::SemId;
 use crate::contract::Opout;
 use crate::schema::{self, SchemaId};
 use crate::{
-    AssignmentType, BundleId, ContractId, Layer1, OccurrencesMismatch, OpFullType, OpId,
+    AssignmentType, BundleId, ContractId, Layer1, OccurrencesMismatch, OpFullType, OpId, OpType,
     SecretSeal, StateType, Vin, XChain, XGraphSeal, XOutputSeal, XWitnessId,
 };
 
@@ -237,6 +237,12 @@ pub enum Failure {
     CyclicGraph(OpId),
     /// operation {0} is absent from the consignment.
     OperationAbsent(OpId),
+    /// {ty} data doesn't match operation id {expected} (actual id is {actual}).
+    OperationIdMismatch {
+        ty: OpType,
+        expected: OpId,
+        actual: OpId,
+    },
     /// transition bundle {0} referenced in consignment terminals is absent from
     /// the consignment.
     TerminalBundleAbsent(BundleId),

--- a/src/validation/validator.rs
+++ b/src/validation/validator.rs
@@ -230,10 +230,13 @@ impl<'consignment, 'resolver, C: ConsignmentApi, R: ResolveWitness>
     fn validate_logic_on_route(&self, opid: OpId) {
         let schema = self.consignment.schema();
         let Some(OpRef::Transition(transition)) = self.consignment.operation(opid) else {
-            panic!("provided {opid} is absent");
+            self.status
+                .borrow_mut()
+                .add_failure(Failure::OperationAbsent(opid));
+            return;
         };
 
-        let mut queue: VecDeque<OpRef> = VecDeque::new();
+        let mut queue: VecDeque<(OpId, OpRef)> = VecDeque::new();
 
         // Instead of constructing complex graph structures or using a recursions we
         // utilize queue to keep the track of the upstream (ancestor) nodes and make
@@ -244,9 +247,18 @@ impl<'consignment, 'resolver, C: ConsignmentApi, R: ResolveWitness>
         // change to a given operation is valid against the schema + committed
         // into bitcoin transaction graph with proper anchor. That is what we are
         // checking in the code below:
-        queue.push_back(OpRef::Transition(transition));
-        while let Some(operation) = queue.pop_front() {
-            let opid = operation.id();
+        queue.push_back((opid, OpRef::Transition(transition)));
+        while let Some((opid, operation)) = queue.pop_front() {
+            let actual_opid = operation.id();
+            if opid != actual_opid {
+                self.status
+                    .borrow_mut()
+                    .add_failure(Failure::OperationIdMismatch {
+                        ty: operation.op_type(),
+                        expected: opid,
+                        actual: actual_opid,
+                    });
+            }
 
             if operation.contract_id() != self.contract_id {
                 self.status
@@ -274,12 +286,15 @@ impl<'consignment, 'resolver, C: ConsignmentApi, R: ResolveWitness>
                 OpRef::Transition(transition) => {
                     // Now, we must collect all parent nodes and add them to the verification queue
                     let parent_nodes = transition.inputs.iter().filter_map(|input| {
-                        self.consignment.operation(input.prev_out.op).or_else(|| {
-                            self.status
-                                .borrow_mut()
-                                .add_failure(Failure::OperationAbsent(input.prev_out.op));
-                            None
-                        })
+                        self.consignment
+                            .operation(input.prev_out.op)
+                            .map(|op| (input.prev_out.op, op))
+                            .or_else(|| {
+                                self.status
+                                    .borrow_mut()
+                                    .add_failure(Failure::OperationAbsent(input.prev_out.op));
+                                None
+                            })
                     });
 
                     queue.extend(parent_nodes);
@@ -308,7 +323,7 @@ impl<'consignment, 'resolver, C: ConsignmentApi, R: ResolveWitness>
                             continue;
                         }
 
-                        queue.push_back(prev_op);
+                        queue.push_back((*prev_id, prev_op));
                     }
                 }
             }

--- a/src/validation/validator.rs
+++ b/src/validation/validator.rs
@@ -407,19 +407,14 @@ impl<'consignment, 'resolver, C: ConsignmentApi, R: ResolveWitness>
                 // Reporting this incident and continuing further. Why this happens? No
                 // connection to Bitcoin Core, Electrum or other backend etc. So this is not a
                 // failure in a strict sense, however we can't be sure that the consignment is
-                // valid. That's why we keep the track of such information in a separate place
-                // (`unresolved_txids` field of the validation status object).
-                self.status
-                    .borrow_mut()
-                    .absent_pub_witnesses
-                    .push(witness_id);
+                // valid.
                 // This also can mean that there is no known transaction with the id provided by
                 // the anchor, i.e. consignment is invalid. We are proceeding with further
                 // validation in order to detect the rest of problems (and reporting the
                 // failure!)
                 self.status
                     .borrow_mut()
-                    .add_failure(Failure::SealNoWitnessTx(witness_id));
+                    .add_failure(Failure::SealNoPubWitness(witness_id));
                 None
             }
             Ok(pub_witness) => {


### PR DESCRIPTION
Closes #259, #254

With the recent clarification on the use of resolvers and consignment-stored transaction ("public witness") information (see [RCP-240313A](https://github.com/RGB-WG/RFC/issues/3) for the details) there is no reason to provide separate fields listing unresolved transaction/witnesses - they all can be retrieved from `Failure::SealNoPubWitness` variants when iterating over `failures` vector.

I also moved `UncheckableConfidentialState` from `info` to `warning` (since it is the client who needs to decide whether this is important) and removed unused warning variant.