### PR TITLE
Fix consensus ordering for cross-chains

### DIFF
--- a/src/stl.rs
+++ b/src/stl.rs
@@ -40,7 +40,7 @@ pub const LIB_ID_RGB_COMMIT: &str =
     "stl:ZMTVCU25-QDo98xR-wI91wcu-ydb7kui-QfZbF$n-0KDS2ow#tuna-safari-design";
 /// Strict types id for the library providing data types for RGB consensus.
 pub const LIB_ID_RGB_LOGIC: &str =
-    "stl:bioTBozT-NqelHGE-SPbnpMA-XBNSbXZ-6X0dANE-WHVirL8#explain-marvin-bless";
+    "stl:IKFjGiNg-4MC4DKp-6XBvG0D-FCMXfqx-OnKhuRH-nb75Mcs#sector-season-anatomy";
 
 fn _rgb_commit_stl() -> Result<TypeLib, CompileError> {
     LibBuilder::new(libname!(LIB_NAME_RGB_COMMIT), tiny_bset! {

--- a/src/vm/contract.rs
+++ b/src/vm/contract.rs
@@ -375,12 +375,12 @@ impl Ord for WitnessPos {
         match (self.layer1, other.layer1) {
             (a, b) if a == b => self.height.cmp(&other.height),
             (Layer1::Bitcoin, Layer1::Liquid)
-                if (self.timestamp - other.timestamp).abs() >= BLOCK_TIME =>
+                if (self.timestamp - other.timestamp).abs() < BLOCK_TIME =>
             {
                 Ordering::Greater
             }
             (Layer1::Liquid, Layer1::Bitcoin)
-                if (other.timestamp - self.timestamp).abs() >= BLOCK_TIME =>
+                if (other.timestamp - self.timestamp).abs() < BLOCK_TIME =>
             {
                 Ordering::Less
             }


### PR DESCRIPTION
Implementation of [RCP-20241013A](https://github.com/RGB-WG/RFC/issues/13)

Alternative to #274 which takes care of situations where 
- blocks on testnet have timestamps which ordering is not aligned with the height
- two different chains are used, and one doesn't report timestamps properly