### PR TITLE
Add new operators to avoid pedersen commitments in amount validation

### DIFF
--- a/src/vm/macroasm.rs
+++ b/src/vm/macroasm.rs
@@ -36,6 +36,9 @@ macro_rules! isa_instr {
     (pcvs $no:ident) => {{ RgbIsa::Contract(ContractOp::Pcvs($no)) }};
     (pcas $no:ident) => {{ RgbIsa::Contract(ContractOp::Pcas($no)) }};
     (pcps $no:ident) => {{ RgbIsa::Contract(ContractOp::Pcps($no)) }};
+    (svs $no:ident) => {{ RgbIsa::Contract(ContractOp::Svs($no)) }};
+    (sas $no:ident) => {{ RgbIsa::Contract(ContractOp::Sas($no)) }};
+    (sps $no:ident) => {{ RgbIsa::Contract(ContractOp::Sps($no)) }};
     (cng $t:ident,a8[$a_idx:literal]) => {{ RgbIsa::Contract(ContractOp::CnG($t, Reg32::from(u5::with($a_idx)))) }};
     (cnc $t:ident,a16[$a_idx:literal]) => {{ RgbIsa::Contract(ContractOp::CnC($t, Reg32::from(u5::with($a_idx)))) }};
     (ldm $t:ident,s16[$s_idx:literal]) => {{ RgbIsa::Contract(ContractOp::LdM($t, RegS::from($s_idx))) }};

--- a/src/vm/opcodes.rs
+++ b/src/vm/opcodes.rs
@@ -47,8 +47,11 @@ pub const INSTR_PCVS: u8 = 0b11_010_000;
 pub const INSTR_PCAS: u8 = 0b11_010_001;
 pub const INSTR_PCPS: u8 = 0b11_010_010;
 // Reserved 0b11_010_011
+pub const INSTR_SVS: u8 = 0b11_010_100;
+pub const INSTR_SAS: u8 = 0b11_010_101;
+pub const INSTR_SPS: u8 = 0b11_010_110;
 pub const INSTR_CONTRACT_FROM: u8 = 0b11_000_000;
-pub const INSTR_CONTRACT_TO: u8 = 0b11_010_011;
+pub const INSTR_CONTRACT_TO: u8 = 0b11_011_011;
 
 // TIMECHAIN:
 pub const INSTR_TIMECHAIN_FROM: u8 = 0b11_011_100;


### PR DESCRIPTION
Validation for NIA contracts currently involves pedersen commitments to verify that the sum of inputs equals the sum of outputs. Since bulletproofs are still not an option, amounts are included in clear within the consignment. Hence, given pedersen commitments are constructed by the receiver during validation, this currently brings no advantages over a simple sum verification, but we still want to keep them so that bulletproof can be added in a backwards compatible update.

This PR introduces 3 new AluVM operators that behave like their pedersen commitment counterparts but only do simple sums. This should bring the following advantages:
- no cryptographic operations where they're not necessary, which should simplify audit
- no dependency on `secp256k1-zkp` in case we put pedersen commitment operations behind a feature flag
- performance improvement, even though this doesn't seem to be a bottleneck for now

The new operators can be used by schema developers to create schemas corresponding to NIA and CFA that only work with revealed state.